### PR TITLE
Refactor MainViewModel: Extract Simulation and Custom Entry Coordinators

### DIFF
--- a/ModbusForge/App.xaml.cs
+++ b/ModbusForge/App.xaml.cs
@@ -86,6 +86,7 @@ namespace ModbusForge
             services.AddSingleton<CustomEntryCoordinator>();
             services.AddSingleton<TrendCoordinator>();
             services.AddSingleton<ConfigurationCoordinator>();
+            services.AddSingleton<SimulationCoordinator>();
             
             // Register ViewModels
             services.AddSingleton<MainViewModel>();

--- a/ModbusForge/MainWindow.xaml
+++ b/ModbusForge/MainWindow.xaml
@@ -364,9 +364,9 @@
 
                     <!-- Toolbar -->
                     <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
-                        <CheckBox Content="Enable Simulation" IsChecked="{Binding SimulationEnabled}" VerticalAlignment="Center"/>
+                        <CheckBox Content="Enable Simulation" IsChecked="{Binding SimulationCoordinator.SimulationEnabled}" VerticalAlignment="Center"/>
                         <TextBlock Text=" Period (ms):" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                        <TextBox Width="80" Text="{Binding SimulationPeriodMs}"/>
+                        <TextBox Width="80" Text="{Binding SimulationCoordinator.SimulationPeriodMs}"/>
                         <TextBlock VerticalAlignment="Center" Foreground="Gray" Margin="10,0,0,0">
                             <Run Text="Note:" FontWeight="SemiBold"/>
                             <Run Text=" Server mode only."/>
@@ -378,25 +378,25 @@
                         <GroupBox Header="Holding Registers (Waveform)">
                             <StackPanel Orientation="Vertical" Margin="5">
                                 <StackPanel Orientation="Horizontal">
-                                    <CheckBox Content="Enable" IsChecked="{Binding SimHoldingsEnabled}" VerticalAlignment="Center"/>
+                                    <CheckBox Content="Enable" IsChecked="{Binding SimulationCoordinator.SimHoldingsEnabled}" VerticalAlignment="Center"/>
                                     <TextBlock Text=" Start:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                    <TextBox Width="80" Text="{Binding SimHoldingStart}"/>
+                                    <TextBox Width="80" Text="{Binding SimulationCoordinator.SimHoldingStart}"/>
                                     <TextBlock Text=" Count:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                    <TextBox Width="80" Text="{Binding SimHoldingCount}"/>
+                                    <TextBox Width="80" Text="{Binding SimulationCoordinator.SimHoldingCount}"/>
                                     <TextBlock Text=" Min:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                    <TextBox Width="80" Text="{Binding SimHoldingMin}"/>
+                                    <TextBox Width="80" Text="{Binding SimulationCoordinator.SimHoldingMin}"/>
                                     <TextBlock Text=" Max:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                    <TextBox Width="80" Text="{Binding SimHoldingMax}"/>
+                                    <TextBox Width="80" Text="{Binding SimulationCoordinator.SimHoldingMax}"/>
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                                     <TextBlock Text=" Waveform:" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                                    <ComboBox Width="100" SelectedItem="{Binding SimHoldingWaveformType}" ItemsSource="{StaticResource WaveformOptionsAll}"/>
+                                    <ComboBox Width="100" SelectedItem="{Binding SimulationCoordinator.SimHoldingWaveformType}" ItemsSource="{StaticResource WaveformOptionsAll}"/>
                                     <TextBlock Text=" Amp:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                    <TextBox Width="80" Text="{Binding SimHoldingAmplitude}"/>
+                                    <TextBox Width="80" Text="{Binding SimulationCoordinator.SimHoldingAmplitude}"/>
                                     <TextBlock Text=" Freq (Hz):" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                    <TextBox Width="80" Text="{Binding SimHoldingFrequencyHz}"/>
+                                    <TextBox Width="80" Text="{Binding SimulationCoordinator.SimHoldingFrequencyHz}"/>
                                     <TextBlock Text=" Offset:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                    <TextBox Width="80" Text="{Binding SimHoldingOffset}"/>
+                                    <TextBox Width="80" Text="{Binding SimulationCoordinator.SimHoldingOffset}"/>
                                 </StackPanel>
                                 <TextBlock Foreground="Gray" Margin="0,4,0,0">
                                     <Run Text="Note:" FontWeight="SemiBold"/>
@@ -407,35 +407,35 @@
 
                         <GroupBox Header="Coils (Toggle)">
                             <StackPanel Orientation="Horizontal" Margin="5">
-                                <CheckBox Content="Enable" IsChecked="{Binding SimCoilsEnabled}" VerticalAlignment="Center"/>
+                                <CheckBox Content="Enable" IsChecked="{Binding SimulationCoordinator.SimCoilsEnabled}" VerticalAlignment="Center"/>
                                 <TextBlock Text=" Start:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                <TextBox Width="80" Text="{Binding SimCoilStart}"/>
+                                <TextBox Width="80" Text="{Binding SimulationCoordinator.SimCoilStart}"/>
                                 <TextBlock Text=" Count:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                <TextBox Width="80" Text="{Binding SimCoilCount}"/>
+                                <TextBox Width="80" Text="{Binding SimulationCoordinator.SimCoilCount}"/>
                             </StackPanel>
                         </GroupBox>
 
                         <GroupBox Header="Input Registers (Ramp)">
                             <StackPanel Orientation="Horizontal" Margin="5">
-                                <CheckBox Content="Enable" IsChecked="{Binding SimInputsEnabled}" VerticalAlignment="Center"/>
+                                <CheckBox Content="Enable" IsChecked="{Binding SimulationCoordinator.SimInputsEnabled}" VerticalAlignment="Center"/>
                                 <TextBlock Text=" Start:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                <TextBox Width="80" Text="{Binding SimInputStart}"/>
+                                <TextBox Width="80" Text="{Binding SimulationCoordinator.SimInputStart}"/>
                                 <TextBlock Text=" Count:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                <TextBox Width="80" Text="{Binding SimInputCount}"/>
+                                <TextBox Width="80" Text="{Binding SimulationCoordinator.SimInputCount}"/>
                                 <TextBlock Text=" Min:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                <TextBox Width="80" Text="{Binding SimInputMin}"/>
+                                <TextBox Width="80" Text="{Binding SimulationCoordinator.SimInputMin}"/>
                                 <TextBlock Text=" Max:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                <TextBox Width="80" Text="{Binding SimInputMax}"/>
+                                <TextBox Width="80" Text="{Binding SimulationCoordinator.SimInputMax}"/>
                             </StackPanel>
                         </GroupBox>
 
                         <GroupBox Header="Discrete Inputs (Toggle)">
                             <StackPanel Orientation="Horizontal" Margin="5">
-                                <CheckBox Content="Enable" IsChecked="{Binding SimDiscreteEnabled}" VerticalAlignment="Center"/>
+                                <CheckBox Content="Enable" IsChecked="{Binding SimulationCoordinator.SimDiscreteEnabled}" VerticalAlignment="Center"/>
                                 <TextBlock Text=" Start:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                <TextBox Width="80" Text="{Binding SimDiscreteStart}"/>
+                                <TextBox Width="80" Text="{Binding SimulationCoordinator.SimDiscreteStart}"/>
                                 <TextBlock Text=" Count:" VerticalAlignment="Center" Margin="10,0,5,0"/>
-                                <TextBox Width="80" Text="{Binding SimDiscreteCount}"/>
+                                <TextBox Width="80" Text="{Binding SimulationCoordinator.SimDiscreteCount}"/>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>

--- a/ModbusForge/Services/ISimulationService.cs
+++ b/ModbusForge/Services/ISimulationService.cs
@@ -1,10 +1,10 @@
 namespace ModbusForge.Services
 {
-    using ModbusForge.ViewModels;
+    using ModbusForge.ViewModels.Coordinators;
 
     public interface ISimulationService
     {
-        void Start(MainViewModel viewModel);
+        void Start(SimulationCoordinator coordinator);
         void Stop();
     }
 }

--- a/ModbusForge/Services/SimulationService.cs
+++ b/ModbusForge/Services/SimulationService.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Windows.Threading;
-using ModbusForge.ViewModels;
+using ModbusForge.ViewModels.Coordinators;
 using Microsoft.Extensions.Logging;
 
 namespace ModbusForge.Services
 {
     public class SimulationService : ISimulationService, IDisposable
     {
-        private MainViewModel? _viewModel;
+        private SimulationCoordinator? _coordinator;
         private readonly ModbusServerService _serverService;
         private readonly ILogger<SimulationService> _logger;
         private DispatcherTimer? _simulationTimer;
@@ -24,20 +24,20 @@ namespace ModbusForge.Services
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public void Start(MainViewModel viewModel)
+        public void Start(SimulationCoordinator coordinator)
         {
-            _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+            _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
             if (_simulationTimer == null)
             {
                 _simulationTimer = new DispatcherTimer
                 {
-                    Interval = TimeSpan.FromMilliseconds(Math.Max(50, _viewModel.SimulationPeriodMs))
+                    Interval = TimeSpan.FromMilliseconds(Math.Max(50, _coordinator.SimulationPeriodMs))
                 };
                 _simulationTimer.Tick += SimulationTimer_Tick;
             }
             else
             {
-                _simulationTimer.Interval = TimeSpan.FromMilliseconds(Math.Max(50, _viewModel.SimulationPeriodMs));
+                _simulationTimer.Interval = TimeSpan.FromMilliseconds(Math.Max(50, _coordinator.SimulationPeriodMs));
             }
             _lastSimTickUtc = DateTime.UtcNow;
             _simulationTimer.Start();
@@ -50,11 +50,13 @@ namespace ModbusForge.Services
 
         private void SimulationTimer_Tick(object? sender, EventArgs e)
         {
-            if (_viewModel == null) return;
+            if (_coordinator == null) return;
             if (_isSimulating) return;
-            if (!_viewModel.IsConnected) return;
-            if (!_viewModel.IsServerMode) return;
-            if (!_viewModel.SimulationEnabled) return;
+
+            // Simulation only runs when server is running (connected)
+            if (!_serverService.IsConnected) return;
+
+            if (!_coordinator.SimulationEnabled) return;
 
             _isSimulating = true;
             try
@@ -65,16 +67,16 @@ namespace ModbusForge.Services
                 _simTimeSec += dt;
                 _lastSimTickUtc = nowSim;
 
-                if (_viewModel.SimHoldingsEnabled)
+                if (_coordinator.SimHoldingsEnabled)
                 {
-                    int count = _viewModel.SimHoldingCount <= 0 ? 0 : _viewModel.SimHoldingCount;
-                    int start = _viewModel.SimHoldingStart;
-                    int min = _viewModel.SimHoldingMin;
-                    int max = _viewModel.SimHoldingMax;
-                    string wf = (_viewModel.SimHoldingWaveformType ?? "Ramp").ToLowerInvariant();
-                    if ((wf == "sine" || wf == "triangle" || wf == "square") && _viewModel.SimHoldingFrequencyHz > 0)
+                    int count = _coordinator.SimHoldingCount <= 0 ? 0 : _coordinator.SimHoldingCount;
+                    int start = _coordinator.SimHoldingStart;
+                    int min = _coordinator.SimHoldingMin;
+                    int max = _coordinator.SimHoldingMax;
+                    string wf = (_coordinator.SimHoldingWaveformType ?? "Ramp").ToLowerInvariant();
+                    if ((wf == "sine" || wf == "triangle" || wf == "square") && _coordinator.SimHoldingFrequencyHz > 0)
                     {
-                        double f = _viewModel.SimHoldingFrequencyHz;
+                        double f = _coordinator.SimHoldingFrequencyHz;
                         double x = 2.0 * Math.PI * f * _simTimeSec;
                         double w;
                         if (wf == "sine") w = Math.Sin(x);
@@ -86,7 +88,7 @@ namespace ModbusForge.Services
                         }
                         else w = Math.Sin(x) >= 0 ? 1.0 : -1.0;
 
-                        double raw = _viewModel.SimHoldingOffset + (_viewModel.SimHoldingAmplitude * w);
+                        double raw = _coordinator.SimHoldingOffset + (_coordinator.SimHoldingAmplitude * w);
                         int iv = (int)Math.Round(raw);
                         if (iv < 0) iv = 0;
                         if (iv > 65535) iv = 65535;
@@ -121,13 +123,13 @@ namespace ModbusForge.Services
                     }
                 }
 
-                if (_viewModel.SimCoilsEnabled)
+                if (_coordinator.SimCoilsEnabled)
                 {
                     var dataStore = _serverService.GetDataStore();
                     if (dataStore != null)
                     {
-                        int count = _viewModel.SimCoilCount <= 0 ? 0 : _viewModel.SimCoilCount;
-                        int start = _viewModel.SimCoilStart;
+                        int count = _coordinator.SimCoilCount <= 0 ? 0 : _coordinator.SimCoilCount;
+                        int start = _coordinator.SimCoilStart;
                         for (int i = 0; i < count; i++)
                         {
                             int addr = start + i;
@@ -138,15 +140,15 @@ namespace ModbusForge.Services
                     }
                 }
 
-                if (_viewModel.SimInputsEnabled)
+                if (_coordinator.SimInputsEnabled)
                 {
                     var dataStore = _serverService.GetDataStore();
                     if (dataStore != null)
                     {
-                        int count = _viewModel.SimInputCount <= 0 ? 0 : _viewModel.SimInputCount;
-                        int start = _viewModel.SimInputStart;
-                        int min = _viewModel.SimInputMin;
-                        int max = _viewModel.SimInputMax;
+                        int count = _coordinator.SimInputCount <= 0 ? 0 : _coordinator.SimInputCount;
+                        int start = _coordinator.SimInputStart;
+                        int min = _coordinator.SimInputMin;
+                        int max = _coordinator.SimInputMax;
                         int range = Math.Max(1, max - min + 1);
                         _simHoldingPhase = (_simHoldingPhase + 1) % range;
                         for (int i = 0; i < count; i++)
@@ -161,13 +163,13 @@ namespace ModbusForge.Services
                     }
                 }
 
-                if (_viewModel.SimDiscreteEnabled)
+                if (_coordinator.SimDiscreteEnabled)
                 {
                     var dataStore = _serverService.GetDataStore();
                     if (dataStore != null)
                     {
-                        int count = _viewModel.SimDiscreteCount <= 0 ? 0 : _viewModel.SimDiscreteCount;
-                        int start = _viewModel.SimDiscreteStart;
+                        int count = _coordinator.SimDiscreteCount <= 0 ? 0 : _coordinator.SimDiscreteCount;
+                        int start = _coordinator.SimDiscreteStart;
                         for (int i = 0; i < count; i++)
                         {
                             int addr = start + i;

--- a/ModbusForge/ViewModels/Coordinators/CustomEntryCoordinator.cs
+++ b/ModbusForge/ViewModels/Coordinators/CustomEntryCoordinator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Extensions.Logging;
+using ModbusForge.Helpers;
 using ModbusForge.Models;
 using ModbusForge.Services;
 
@@ -17,15 +18,21 @@ namespace ModbusForge.ViewModels.Coordinators
     {
         private readonly RegisterCoordinator _registerCoordinator;
         private readonly ICustomEntryService _customEntryService;
+        private readonly ModbusTcpService _clientService;
+        private readonly ModbusServerService _serverService;
         private readonly ILogger<CustomEntryCoordinator> _logger;
 
         public CustomEntryCoordinator(
             RegisterCoordinator registerCoordinator,
             ICustomEntryService customEntryService,
+            ModbusTcpService clientService,
+            ModbusServerService serverService,
             ILogger<CustomEntryCoordinator> logger)
         {
             _registerCoordinator = registerCoordinator ?? throw new ArgumentNullException(nameof(registerCoordinator));
             _customEntryService = customEntryService ?? throw new ArgumentNullException(nameof(customEntryService));
+            _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
+            _serverService = serverService ?? throw new ArgumentNullException(nameof(serverService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -144,6 +151,143 @@ namespace ModbusForge.ViewModels.Coordinators
             {
                 setStatusMessage($"Invalid coil value: {entry.Value}. Use true/false or 1/0.");
             }
+        }
+
+        /// <summary>
+        /// Reads a custom entry value.
+        /// </summary>
+        public async Task ReadCustomNowAsync(CustomEntry entry, byte unitId, Action<string> setStatusMessage, bool isServerMode)
+        {
+            if (entry is null) return;
+            try
+            {
+                var area = (entry.Area ?? "HoldingRegister").ToLowerInvariant();
+                switch (area)
+                {
+                    case "holdingregister":
+                        await ReadHoldingRegisterByTypeAsync(entry, unitId, setStatusMessage, isServerMode);
+                        break;
+                    case "inputregister":
+                        await ReadInputRegisterByTypeAsync(entry, unitId, setStatusMessage, isServerMode);
+                        break;
+                    case "coil":
+                        await ReadCoilAsync(entry, unitId, setStatusMessage, isServerMode);
+                        break;
+                    case "discreteinput":
+                        await ReadDiscreteInputAsync(entry, unitId, setStatusMessage, isServerMode);
+                        break;
+                    default:
+                        setStatusMessage($"Unknown area: {entry.Area}");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reading custom entry");
+                setStatusMessage($"Custom read error: {ex.Message}");
+            }
+        }
+
+        private IModbusService GetService(bool isServerMode) => isServerMode ? _serverService : _clientService;
+
+        /// <summary>
+        /// Reads a holding register value based on the entry's data type.
+        /// </summary>
+        private async Task ReadHoldingRegisterByTypeAsync(CustomEntry entry, byte unitId, Action<string> setStatusMessage, bool isServerMode)
+        {
+            var type = (entry.Type ?? "uint").ToLowerInvariant();
+            var address = entry.Address;
+            var service = GetService(isServerMode);
+
+            switch (type)
+            {
+                case "real":
+                    var regsReal = await service.ReadHoldingRegistersAsync(unitId, address, 2);
+                    if (regsReal is null) return;
+                    entry.Value = DataTypeConverter.ToSingle(regsReal[0], regsReal[1]).ToString(CultureInfo.InvariantCulture);
+                    setStatusMessage($"Read REAL {entry.Value} from HR {address}");
+                    break;
+                case "int":
+                    var regsInt = await service.ReadHoldingRegistersAsync(unitId, address, 1);
+                    if (regsInt is null) return;
+                    entry.Value = unchecked((short)regsInt[0]).ToString(CultureInfo.InvariantCulture);
+                    setStatusMessage($"Read INT {entry.Value} from HR {address}");
+                    break;
+                case "string":
+                    var regsString = await service.ReadHoldingRegistersAsync(unitId, address, 1);
+                    if (regsString is null) return;
+                    entry.Value = DataTypeConverter.ToString(regsString[0]);
+                    setStatusMessage($"Read STRING '{entry.Value}' from HR {address}");
+                    break;
+                default: // uint
+                    var regsUInt = await service.ReadHoldingRegistersAsync(unitId, address, 1);
+                    if (regsUInt is null) return;
+                    entry.Value = regsUInt[0].ToString(CultureInfo.InvariantCulture);
+                    setStatusMessage($"Read UINT {entry.Value} from HR {address}");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Reads an input register value based on the entry's data type.
+        /// </summary>
+        private async Task ReadInputRegisterByTypeAsync(CustomEntry entry, byte unitId, Action<string> setStatusMessage, bool isServerMode)
+        {
+            var type = (entry.Type ?? "uint").ToLowerInvariant();
+            var address = entry.Address;
+            var service = GetService(isServerMode);
+
+            switch (type)
+            {
+                case "real":
+                    var regsReal = await service.ReadInputRegistersAsync(unitId, address, 2);
+                    if (regsReal is null) return;
+                    entry.Value = DataTypeConverter.ToSingle(regsReal[0], regsReal[1]).ToString(CultureInfo.InvariantCulture);
+                    setStatusMessage($"Read REAL {entry.Value} from IR {address}");
+                    break;
+                case "int":
+                    var regsInt = await service.ReadInputRegistersAsync(unitId, address, 1);
+                    if (regsInt is null) return;
+                    entry.Value = unchecked((short)regsInt[0]).ToString(CultureInfo.InvariantCulture);
+                    setStatusMessage($"Read INT {entry.Value} from IR {address}");
+                    break;
+                case "string":
+                    var regsString = await service.ReadInputRegistersAsync(unitId, address, 1);
+                    if (regsString is null) return;
+                    entry.Value = DataTypeConverter.ToString(regsString[0]);
+                    setStatusMessage($"Read STRING '{entry.Value}' from IR {address}");
+                    break;
+                default: // uint
+                    var regsUInt = await service.ReadInputRegistersAsync(unitId, address, 1);
+                    if (regsUInt is null) return;
+                    entry.Value = regsUInt[0].ToString(CultureInfo.InvariantCulture);
+                    setStatusMessage($"Read UINT {entry.Value} from IR {address}");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Reads a coil (boolean) value.
+        /// </summary>
+        private async Task ReadCoilAsync(CustomEntry entry, byte unitId, Action<string> setStatusMessage, bool isServerMode)
+        {
+            var service = GetService(isServerMode);
+            var states = await service.ReadCoilsAsync(unitId, entry.Address, 1);
+            if (states is null) return;
+            entry.Value = states[0] ? "1" : "0";
+            setStatusMessage($"Read COIL {entry.Value} from {entry.Address}");
+        }
+
+        /// <summary>
+        /// Reads a discrete input (boolean) value.
+        /// </summary>
+        private async Task ReadDiscreteInputAsync(CustomEntry entry, byte unitId, Action<string> setStatusMessage, bool isServerMode)
+        {
+            var service = GetService(isServerMode);
+            var states = await service.ReadDiscreteInputsAsync(unitId, entry.Address, 1);
+            if (states is null) return;
+            entry.Value = states[0] ? "1" : "0";
+            setStatusMessage($"Read DI {entry.Value} from {entry.Address}");
         }
 
         private static bool TryParseBool(string? value, out bool result)

--- a/ModbusForge/ViewModels/Coordinators/SimulationCoordinator.cs
+++ b/ModbusForge/ViewModels/Coordinators/SimulationCoordinator.cs
@@ -1,0 +1,98 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using ModbusForge.Services;
+using System;
+
+namespace ModbusForge.ViewModels.Coordinators
+{
+    public partial class SimulationCoordinator : ViewModelBase
+    {
+        private readonly ISimulationService _simulationService;
+
+        public SimulationCoordinator(ISimulationService simulationService)
+        {
+            _simulationService = simulationService ?? throw new ArgumentNullException(nameof(simulationService));
+        }
+
+        public void Start()
+        {
+            _simulationService.Start(this);
+        }
+
+        public void Stop()
+        {
+            _simulationService.Stop();
+        }
+
+        // Simulation configuration
+        [ObservableProperty]
+        private bool _simulationEnabled = false;
+
+        [ObservableProperty]
+        private int _simulationPeriodMs = 500;
+
+        // Holding Registers ramp
+        [ObservableProperty]
+        private bool _simHoldingsEnabled = false;
+
+        [ObservableProperty]
+        private int _simHoldingStart = 1;
+
+        [ObservableProperty]
+        private int _simHoldingCount = 4;
+
+        [ObservableProperty]
+        private int _simHoldingMin = 0;
+
+        [ObservableProperty]
+        private int _simHoldingMax = 100;
+
+        // Holding Registers waveform parameters
+        [ObservableProperty]
+        private string _simHoldingWaveformType = "Ramp"; // Ramp, Sine, Triangle, Square
+
+        [ObservableProperty]
+        private double _simHoldingAmplitude = 1000.0;
+
+        [ObservableProperty]
+        private double _simHoldingFrequencyHz = 0.5;
+
+        [ObservableProperty]
+        private double _simHoldingOffset = 0.0;
+
+        // Coils toggle
+        [ObservableProperty]
+        private bool _simCoilsEnabled = false;
+
+        [ObservableProperty]
+        private int _simCoilStart = 1;
+
+        [ObservableProperty]
+        private int _simCoilCount = 8;
+
+        // Input Registers ramp
+        [ObservableProperty]
+        private bool _simInputsEnabled = false;
+
+        [ObservableProperty]
+        private int _simInputStart = 1;
+
+        [ObservableProperty]
+        private int _simInputCount = 4;
+
+        [ObservableProperty]
+        private int _simInputMin = 0;
+
+        [ObservableProperty]
+        private int _simInputMax = 100;
+
+        // Discrete Inputs toggle
+        [ObservableProperty]
+        private bool _simDiscreteEnabled = false;
+
+        [ObservableProperty]
+        private int _simDiscreteStart = 1;
+
+        [ObservableProperty]
+        private int _simDiscreteCount = 8;
+    }
+}

--- a/ModbusForge/ViewModels/MainViewModel.cs
+++ b/ModbusForge/ViewModels/MainViewModel.cs
@@ -57,14 +57,14 @@ namespace ModbusForge.ViewModels
             App.ServiceProvider.GetRequiredService<ILogger<MainViewModel>>(),
             App.ServiceProvider.GetRequiredService<IOptions<ServerSettings>>(),
             App.ServiceProvider.GetRequiredService<ITrendLogger>(),
-            App.ServiceProvider.GetRequiredService<ISimulationService>(),
             App.ServiceProvider.GetRequiredService<ICustomEntryService>(),
             App.ServiceProvider.GetRequiredService<IConsoleLoggerService>(),
             App.ServiceProvider.GetRequiredService<ConnectionCoordinator>(),
             App.ServiceProvider.GetRequiredService<RegisterCoordinator>(),
             App.ServiceProvider.GetRequiredService<CustomEntryCoordinator>(),
             App.ServiceProvider.GetRequiredService<TrendCoordinator>(),
-            App.ServiceProvider.GetRequiredService<ConfigurationCoordinator>())
+            App.ServiceProvider.GetRequiredService<ConfigurationCoordinator>(),
+            App.ServiceProvider.GetRequiredService<SimulationCoordinator>())
         {
         }
 
@@ -74,20 +74,21 @@ namespace ModbusForge.ViewModels
             var snapshot = CustomEntries.ToList();
             foreach (var ce in snapshot)
             {
-                try { await ReadCustomNowAsync(ce); }
+                try { await _customEntryCoordinator.ReadCustomNowAsync(ce, UnitId, msg => StatusMessage = msg, IsServerMode); }
                 catch (Exception ex) { _logger.LogDebug(ex, "ReadAllCustomNow: failed for {Area} {Address}", ce.Area, ce.Address); }
             }
             StatusMessage = $"Read {snapshot.Count} custom entries";
         }
 
-        public MainViewModel(ModbusTcpService clientService, ModbusServerService serverService, ILogger<MainViewModel> logger, IOptions<ServerSettings> options, ITrendLogger trendLogger, ISimulationService simulationService, ICustomEntryService customEntryService, IConsoleLoggerService consoleLoggerService, ConnectionCoordinator connectionCoordinator, RegisterCoordinator registerCoordinator, CustomEntryCoordinator customEntryCoordinator, TrendCoordinator trendCoordinator, ConfigurationCoordinator configurationCoordinator)
+        public SimulationCoordinator SimulationCoordinator { get; }
+
+        public MainViewModel(ModbusTcpService clientService, ModbusServerService serverService, ILogger<MainViewModel> logger, IOptions<ServerSettings> options, ITrendLogger trendLogger, ICustomEntryService customEntryService, IConsoleLoggerService consoleLoggerService, ConnectionCoordinator connectionCoordinator, RegisterCoordinator registerCoordinator, CustomEntryCoordinator customEntryCoordinator, TrendCoordinator trendCoordinator, ConfigurationCoordinator configurationCoordinator, SimulationCoordinator simulationCoordinator)
         {
             // Store dependencies
             _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
             _serverService = serverService ?? throw new ArgumentNullException(nameof(serverService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _trendLogger = trendLogger ?? throw new ArgumentNullException(nameof(trendLogger));
-            _simulationService = simulationService ?? throw new ArgumentNullException(nameof(simulationService));
             _customEntryService = customEntryService ?? throw new ArgumentNullException(nameof(customEntryService));
             _consoleLoggerService = consoleLoggerService ?? throw new ArgumentNullException(nameof(consoleLoggerService));
             _connectionCoordinator = connectionCoordinator ?? throw new ArgumentNullException(nameof(connectionCoordinator));
@@ -95,6 +96,7 @@ namespace ModbusForge.ViewModels
             _customEntryCoordinator = customEntryCoordinator ?? throw new ArgumentNullException(nameof(customEntryCoordinator));
             _trendCoordinator = trendCoordinator ?? throw new ArgumentNullException(nameof(trendCoordinator));
             _configurationCoordinator = configurationCoordinator ?? throw new ArgumentNullException(nameof(configurationCoordinator));
+            SimulationCoordinator = simulationCoordinator ?? throw new ArgumentNullException(nameof(simulationCoordinator));
             var settings = options?.Value ?? new ServerSettings();
 
             // Initialize in logical order
@@ -172,7 +174,7 @@ namespace ModbusForge.ViewModels
             ReadCustomNowCommand = new AsyncRelayCommand<object?>(async param =>
             {
                 if (param is CustomEntry ce)
-                    await ReadCustomNowAsync(ce);
+                    await _customEntryCoordinator.ReadCustomNowAsync(ce, UnitId, msg => StatusMessage = msg, IsServerMode);
             });
             ReadAllCustomNowCommand = new RelayCommand(async () => await ReadAllCustomNowAsync());
             SaveCustomCommand = new RelayCommand(async () => await SaveCustomAsync());
@@ -260,7 +262,7 @@ namespace ModbusForge.ViewModels
             // Start services
             try { _trendLogger.Start(); } catch { }
             SubscribeCustomEntries();
-            _simulationService.Start(this);
+            SimulationCoordinator.Start();
         }
 
         [ObservableProperty]
@@ -386,7 +388,6 @@ namespace ModbusForge.ViewModels
         private readonly ITrendLogger _trendLogger;
         private readonly ICustomEntryService _customEntryService;
         private bool _isMonitoring;
-        private readonly ISimulationService _simulationService;
         private DateTime _lastHoldingReadUtc = DateTime.MinValue;
         private DateTime _lastInputRegReadUtc = DateTime.MinValue;
         private DateTime _lastCoilsReadUtc = DateTime.MinValue;
@@ -454,77 +455,6 @@ namespace ModbusForge.ViewModels
         [ObservableProperty]
         private int _discreteInputsMonitorPeriodMs = 1000;
 
-        // Simulation tab configuration
-        [ObservableProperty]
-        private bool _simulationEnabled = false;
-
-        [ObservableProperty]
-        private int _simulationPeriodMs = 500;
-
-        // Holding Registers ramp
-        [ObservableProperty]
-        private bool _simHoldingsEnabled = false;
-
-        [ObservableProperty]
-        private int _simHoldingStart = 1;
-
-        [ObservableProperty]
-        private int _simHoldingCount = 4;
-
-        [ObservableProperty]
-        private int _simHoldingMin = 0;
-
-        [ObservableProperty]
-        private int _simHoldingMax = 100;
-
-        // Holding Registers waveform parameters
-        [ObservableProperty]
-        private string _simHoldingWaveformType = "Ramp"; // Ramp, Sine, Triangle, Square
-
-        [ObservableProperty]
-        private double _simHoldingAmplitude = 1000.0;
-
-        [ObservableProperty]
-        private double _simHoldingFrequencyHz = 0.5;
-
-        [ObservableProperty]
-        private double _simHoldingOffset = 0.0;
-
-        // Coils toggle
-        [ObservableProperty]
-        private bool _simCoilsEnabled = false;
-
-        [ObservableProperty]
-        private int _simCoilStart = 1;
-
-        [ObservableProperty]
-        private int _simCoilCount = 8;
-
-        // Input Registers ramp
-        [ObservableProperty]
-        private bool _simInputsEnabled = false;
-
-        [ObservableProperty]
-        private int _simInputStart = 1;
-
-        [ObservableProperty]
-        private int _simInputCount = 4;
-
-        [ObservableProperty]
-        private int _simInputMin = 0;
-
-        [ObservableProperty]
-        private int _simInputMax = 100;
-
-        // Discrete Inputs toggle
-        [ObservableProperty]
-        private bool _simDiscreteEnabled = false;
-
-        [ObservableProperty]
-        private int _simDiscreteStart = 1;
-
-        [ObservableProperty]
-        private int _simDiscreteCount = 8;
 
 
         private bool CanConnect() => _connectionCoordinator.CanConnect(IsConnected);
@@ -630,7 +560,7 @@ namespace ModbusForge.ViewModels
                         _monitorTimer.Tick -= MonitorTimer_Tick;
                         _trendTimer.Stop();
                         _trendTimer.Tick -= TrendTimer_Tick;
-                        _simulationService.Stop();
+                        SimulationCoordinator.Stop();
                         try { _trendLogger.Stop(); } catch { }
                         try
                         {
@@ -800,133 +730,6 @@ namespace ModbusForge.ViewModels
             }
         }
 
-        private async Task ReadCustomNowAsync(CustomEntry entry)
-        {
-            if (entry is null) return;
-            try
-            {
-                var area = (entry.Area ?? "HoldingRegister").ToLowerInvariant();
-                switch (area)
-                {
-                    case "holdingregister":
-                        await ReadHoldingRegisterByTypeAsync(entry);
-                        break;
-                    case "inputregister":
-                        await ReadInputRegisterByTypeAsync(entry);
-                        break;
-                    case "coil":
-                        await ReadCoilAsync(entry);
-                        break;
-                    case "discreteinput":
-                        await ReadDiscreteInputAsync(entry);
-                        break;
-                    default:
-                        StatusMessage = $"Unknown area: {entry.Area}";
-                        break;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error reading custom entry");
-                StatusMessage = $"Custom read error: {ex.Message}";
-            }
-        }
-
-        /// <summary>
-        /// Reads a holding register value based on the entry's data type.
-        /// </summary>
-        private async Task ReadHoldingRegisterByTypeAsync(CustomEntry entry)
-        {
-            var type = (entry.Type ?? "uint").ToLowerInvariant();
-            var address = entry.Address;
-            
-            switch (type)
-            {
-                case "real":
-                    var regsReal = await _modbusService.ReadHoldingRegistersAsync(UnitId, address, 2);
-                    if (regsReal is null) return;
-                    entry.Value = DataTypeConverter.ToSingle(regsReal[0], regsReal[1]).ToString(CultureInfo.InvariantCulture);
-                    StatusMessage = $"Read REAL {entry.Value} from HR {address}";
-                    break;
-                case "int":
-                    var regsInt = await _modbusService.ReadHoldingRegistersAsync(UnitId, address, 1);
-                    if (regsInt is null) return;
-                    entry.Value = unchecked((short)regsInt[0]).ToString(CultureInfo.InvariantCulture);
-                    StatusMessage = $"Read INT {entry.Value} from HR {address}";
-                    break;
-                case "string":
-                    var regsString = await _modbusService.ReadHoldingRegistersAsync(UnitId, address, 1);
-                    if (regsString is null) return;
-                    entry.Value = DataTypeConverter.ToString(regsString[0]);
-                    StatusMessage = $"Read STRING '{entry.Value}' from HR {address}";
-                    break;
-                default: // uint
-                    var regsUInt = await _modbusService.ReadHoldingRegistersAsync(UnitId, address, 1);
-                    if (regsUInt is null) return;
-                    entry.Value = regsUInt[0].ToString(CultureInfo.InvariantCulture);
-                    StatusMessage = $"Read UINT {entry.Value} from HR {address}";
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Reads an input register value based on the entry's data type.
-        /// </summary>
-        private async Task ReadInputRegisterByTypeAsync(CustomEntry entry)
-        {
-            var type = (entry.Type ?? "uint").ToLowerInvariant();
-            var address = entry.Address;
-            
-            switch (type)
-            {
-                case "real":
-                    var regsReal = await _modbusService.ReadInputRegistersAsync(UnitId, address, 2);
-                    if (regsReal is null) return;
-                    entry.Value = DataTypeConverter.ToSingle(regsReal[0], regsReal[1]).ToString(CultureInfo.InvariantCulture);
-                    StatusMessage = $"Read REAL {entry.Value} from IR {address}";
-                    break;
-                case "int":
-                    var regsInt = await _modbusService.ReadInputRegistersAsync(UnitId, address, 1);
-                    if (regsInt is null) return;
-                    entry.Value = unchecked((short)regsInt[0]).ToString(CultureInfo.InvariantCulture);
-                    StatusMessage = $"Read INT {entry.Value} from IR {address}";
-                    break;
-                case "string":
-                    var regsString = await _modbusService.ReadInputRegistersAsync(UnitId, address, 1);
-                    if (regsString is null) return;
-                    entry.Value = DataTypeConverter.ToString(regsString[0]);
-                    StatusMessage = $"Read STRING '{entry.Value}' from IR {address}";
-                    break;
-                default: // uint
-                    var regsUInt = await _modbusService.ReadInputRegistersAsync(UnitId, address, 1);
-                    if (regsUInt is null) return;
-                    entry.Value = regsUInt[0].ToString(CultureInfo.InvariantCulture);
-                    StatusMessage = $"Read UINT {entry.Value} from IR {address}";
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Reads a coil (boolean) value.
-        /// </summary>
-        private async Task ReadCoilAsync(CustomEntry entry)
-        {
-            var states = await _modbusService.ReadCoilsAsync(UnitId, entry.Address, 1);
-            if (states is null) return;
-            entry.Value = states[0] ? "1" : "0";
-            StatusMessage = $"Read COIL {entry.Value} from {entry.Address}";
-        }
-
-        /// <summary>
-        /// Reads a discrete input (boolean) value.
-        /// </summary>
-        private async Task ReadDiscreteInputAsync(CustomEntry entry)
-        {
-            var states = await _modbusService.ReadDiscreteInputsAsync(UnitId, entry.Address, 1);
-            if (states is null) return;
-            entry.Value = states[0] ? "1" : "0";
-            StatusMessage = $"Read DI {entry.Value} from {entry.Address}";
-        }
 
         private static bool TryParseBool(string? value, out bool result)
         {
@@ -1154,82 +957,6 @@ namespace ModbusForge.ViewModels
                 enabled => GlobalMonitorEnabled = enabled);
         }
 
-        private async Task<double?> ReadValueForTrendAsync(CustomEntry entry)
-        {
-            var area = (entry.Area ?? "HoldingRegister").ToLowerInvariant();
-            switch (area)
-            {
-                case "holdingregister":
-                    {
-                        var t = (entry.Type ?? "uint").ToLowerInvariant();
-                        if (t == "real")
-                        {
-                            var regs = await _modbusService.ReadHoldingRegistersAsync(UnitId, entry.Address, 2);
-                            if (regs is null) return null;
-                            return DataTypeConverter.ToSingle(regs[0], regs[1]);
-                        }
-                        else if (t == "int")
-                        {
-                            var regs = await _modbusService.ReadHoldingRegistersAsync(UnitId, entry.Address, 1);
-                            if (regs is null) return null;
-                            short sv = unchecked((short)regs[0]);
-                            return (double)sv;
-                        }
-                        else if (t == "string")
-                        {
-                            // not a numeric trend; skip
-                            return null;
-                        }
-                        else // uint
-                        {
-                            var regs = await _modbusService.ReadHoldingRegistersAsync(UnitId, entry.Address, 1);
-                            if (regs is null) return null;
-                            return (double)regs[0];
-                        }
-                    }
-                case "inputregister":
-                    {
-                        var t = (entry.Type ?? "uint").ToLowerInvariant();
-                        if (t == "real")
-                        {
-                            var regs = await _modbusService.ReadInputRegistersAsync(UnitId, entry.Address, 2);
-                            if (regs is null) return null;
-                            return DataTypeConverter.ToSingle(regs[0], regs[1]);
-                        }
-                        else if (t == "int")
-                        {
-                            var regs = await _modbusService.ReadInputRegistersAsync(UnitId, entry.Address, 1);
-                            if (regs is null) return null;
-                            short sv = unchecked((short)regs[0]);
-                            return (double)sv;
-                        }
-                        else if (t == "string")
-                        {
-                            return null;
-                        }
-                        else // uint
-                        {
-                            var regs = await _modbusService.ReadInputRegistersAsync(UnitId, entry.Address, 1);
-                            if (regs is null) return null;
-                            return (double)regs[0];
-                        }
-                    }
-                case "coil":
-                    {
-                        var states = await _modbusService.ReadCoilsAsync(UnitId, entry.Address, 1);
-                        if (states is null) return null;
-                        return states[0] ? 1.0 : 0.0;
-                    }
-                case "discreteinput":
-                    {
-                        var states = await _modbusService.ReadDiscreteInputsAsync(UnitId, entry.Address, 1);
-                        if (states is null) return null;
-                        return states[0] ? 1.0 : 0.0;
-                    }
-                default:
-                    return null;
-            }
-        }
 
         private async Task SaveCustomAsync()
         {

--- a/ModbusForge/ViewModels/MainViewModel.cs
+++ b/ModbusForge/ViewModels/MainViewModel.cs
@@ -730,7 +730,6 @@ namespace ModbusForge.ViewModels
             }
         }
 
-
         private static bool TryParseBool(string? value, out bool result)
         {
             result = false;
@@ -956,7 +955,6 @@ namespace ModbusForge.ViewModels
                 IsServerMode,
                 enabled => GlobalMonitorEnabled = enabled);
         }
-
 
         private async Task SaveCustomAsync()
         {


### PR DESCRIPTION
This PR refactors `MainViewModel` to reduce its size and complexity by extracting simulation and custom entry logic into dedicated coordinators.

Changes:
- Created `SimulationCoordinator` in `ModbusForge/ViewModels/Coordinators/`.
- Moved all simulation-related properties from `MainViewModel` to `SimulationCoordinator`.
- Updated `ISimulationService` and `SimulationService` to accept `SimulationCoordinator` instead of `MainViewModel`, decoupling the service from the main view model.
- Updated `CustomEntryCoordinator` to handle `ReadCustomNowAsync` and related helper methods, removing them from `MainViewModel`.
- Updated `MainViewModel` to inject `SimulationCoordinator` and `CustomEntryCoordinator` (with updated dependencies) and delegate operations.
- Updated `MainWindow.xaml` to bind to `SimulationCoordinator` properties.
- Registered `SimulationCoordinator` in `App.xaml.cs`.

This completes the planned refactoring for simulation and custom entry features.

---
*PR created automatically by Jules for task [6209908339971101171](https://jules.google.com/task/6209908339971101171) started by @nokkies*