### PR TITLE
Fix sensitive data exposure in ModbusService logs

### DIFF
--- a/ModbusForge.Tests/ModbusServiceTests.cs
+++ b/ModbusForge.Tests/ModbusServiceTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Modbus.Device;
+using ModbusForge.Services;
+using Moq;
+using Xunit;
+
+namespace ModbusForge.Tests
+{
+    public class ModbusServiceTests : IDisposable
+    {
+        private readonly Mock<ILogger<ModbusService>> _loggerMock;
+        private readonly ModbusService _service;
+        private readonly Mock<IModbusMaster> _modbusMasterMock;
+        private TcpListener _listener;
+        private TcpClient _tcpClient;
+
+        public ModbusServiceTests()
+        {
+            _loggerMock = new Mock<ILogger<ModbusService>>();
+            _service = new ModbusService(_loggerMock.Object);
+            _modbusMasterMock = new Mock<IModbusMaster>();
+
+            // Setup a real TCP connection to satisfy IsConnected check
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            _tcpClient = new TcpClient();
+            _tcpClient.Connect(IPAddress.Loopback, port);
+
+            // Inject the mock client
+            var clientField = typeof(ModbusService).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (clientField != null)
+            {
+                clientField.SetValue(_service, _modbusMasterMock.Object);
+            }
+
+            // Inject the connected TcpClient
+            var tcpClientField = typeof(ModbusService).GetField("_tcpClient", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (tcpClientField != null)
+            {
+                tcpClientField.SetValue(_service, _tcpClient);
+            }
+        }
+
+        [Fact]
+        public async Task WriteSingleRegisterAsync_DoesNotLogSensitiveValue()
+        {
+            // Arrange
+            byte unitId = 1;
+            int registerAddress = 100;
+            ushort sensitiveValue = 12345;
+
+            // Act
+            await _service.WriteSingleRegisterAsync(unitId, registerAddress, sensitiveValue);
+
+            // Assert - Check that the sensitive value is NOT logged
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains(sensitiveValue.ToString())),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Never);
+
+            // Also assert that something WAS logged (to ensure we didn't just remove logging entirely)
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task WriteSingleCoilAsync_DoesNotLogSensitiveValue()
+        {
+            // Arrange
+            byte unitId = 1;
+            int coilAddress = 100;
+            bool sensitiveValue = true;
+
+            // Act
+            await _service.WriteSingleCoilAsync(unitId, coilAddress, sensitiveValue);
+
+            // Assert - Check that the sensitive value is NOT logged
+            string sensitiveString = sensitiveValue.ToString();
+
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains(sensitiveString)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Never);
+
+            // Also assert that something WAS logged
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.AtLeastOnce);
+        }
+
+        public void Dispose()
+        {
+            // ModbusService disposes the TcpClient, but we should clean up the listener
+            _service?.Dispose();
+            _listener?.Stop();
+        }
+    }
+}

--- a/ModbusForge/Services/ModbusService.cs
+++ b/ModbusForge/Services/ModbusService.cs
@@ -144,9 +144,9 @@ namespace ModbusForge.Services
             {
                 try
                 {
-                    _logger.LogDebug($"Writing value {value} to register {registerAddress} (Unit ID: {unitId})");
+                    _logger.LogDebug($"Writing to register {registerAddress} (Unit ID: {unitId})");
                     _client?.WriteSingleRegister(unitId, (ushort)registerAddress, value);
-                    _logger.LogDebug($"Successfully wrote register {registerAddress} with value {value}");
+                    _logger.LogDebug($"Successfully wrote register {registerAddress}");
                 }
                 catch (Exception ex)
                 {
@@ -189,9 +189,9 @@ namespace ModbusForge.Services
             {
                 try
                 {
-                    _logger.LogDebug($"Writing coil at {coilAddress} = {value} (Unit ID: {unitId})");
+                    _logger.LogDebug($"Writing coil at {coilAddress} (Unit ID: {unitId})");
                     _client?.WriteSingleCoil(unitId, (ushort)coilAddress, value);
-                    _logger.LogDebug($"Successfully wrote coil {coilAddress} with value {value}");
+                    _logger.LogDebug($"Successfully wrote coil {coilAddress}");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Fixed a security vulnerability in `ModbusService.cs` where sensitive register values were exposed in debug logs.

### Changes
- Removed the value parameter from the log message in `WriteSingleRegisterAsync`.
- Removed the value parameter from the log message in `WriteSingleCoilAsync`.
- Added a new test file `ModbusForge.Tests/ModbusServiceTests.cs` with regression tests verifying that sensitive values are not present in log messages.

### Verification
- Created a temporary test project targeting `net8.0` (as the main test project targets `net8.0-windows` and cannot run in this environment) and verified that the tests pass.
- Verified that the sensitive value is NOT logged (Times.Never) while the operation is still logged (Times.AtLeastOnce).

---
*PR created automatically by Jules for task [5516296848502351320](https://jules.google.com/task/5516296848502351320) started by @nokkies*