### PR TITLE
🔒 Fix insecure Modbus server binding

### DIFF
--- a/ModbusForge/MainWindow.xaml
+++ b/ModbusForge/MainWindow.xaml
@@ -152,10 +152,10 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock Text="Server:" Grid.Column="0" Style="{StaticResource ModernBodyStyle}" VerticalAlignment="Center" Margin="0,0,8,0" Visibility="{Binding ShowClientFields, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding AddressLabel}" Grid.Column="0" Style="{StaticResource ModernBodyStyle}" VerticalAlignment="Center" Margin="0,0,8,0"/>
                     <TextBox Grid.Column="1" Text="{Binding ServerAddress, UpdateSourceTrigger=PropertyChanged}" 
                              IsEnabled="{Binding IsConnected, Converter={StaticResource InverseBooleanConverter}}" 
-                             Margin="0,0,16,0" Visibility="{Binding ShowClientFields, Converter={StaticResource BoolToVis}}"/>
+                             Margin="0,0,16,0"/>
 
                     <TextBlock Text="Port:" Grid.Column="2" Style="{StaticResource ModernBodyStyle}" VerticalAlignment="Center" Margin="0,0,8,0"/>
                     <TextBox Grid.Column="3" Text="{Binding Port}" 

--- a/ModbusForge/Services/ModbusServerService.cs
+++ b/ModbusForge/Services/ModbusServerService.cs
@@ -94,7 +94,10 @@ namespace ModbusForge.Services
                         if (_isRunning)
                             return true;
 
-                        var endpoint = new IPEndPoint(IPAddress.Any, port == 0 ? DefaultPort : port);
+                        if (!IPAddress.TryParse(ipAddress, out var address))
+                            throw new ArgumentException($"Invalid IP address: {ipAddress}");
+
+                        var endpoint = new IPEndPoint(address, port == 0 ? DefaultPort : port);
                     
                     // Create data store
                     _dataStore = new DataStore();

--- a/ModbusForge/ViewModels/MainViewModel.cs
+++ b/ModbusForge/ViewModels/MainViewModel.cs
@@ -50,6 +50,7 @@ namespace ModbusForge.ViewModels
         public bool ShowClientFields => !IsServerMode; // show IP/UnitId only in client mode
         public string ConnectButtonText => IsServerMode ? "Start Server" : "Connect";
         public string ConnectionHeader => IsServerMode ? "Modbus Connection (Server)" : "Modbus Connection (Client)";
+        public string AddressLabel => IsServerMode ? "Interface:" : "Server:";
 
         public MainViewModel() : this(
             App.ServiceProvider.GetRequiredService<ModbusTcpService>(),
@@ -293,6 +294,7 @@ namespace ModbusForge.ViewModels
                 OnPropertyChanged(nameof(ShowClientFields));
                 OnPropertyChanged(nameof(ConnectButtonText));
                 OnPropertyChanged(nameof(ConnectionHeader));
+                OnPropertyChanged(nameof(AddressLabel));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- **Vulnerability:** The Modbus server was hardcoded to bind to `IPAddress.Any` (0.0.0.0), exposing it to all network interfaces regardless of user intent.
- **Fix:** Updated `ModbusServerService.ConnectAsync` to respect the provided `ipAddress` parameter. It now parses the IP and binds specifically to it. If the IP is invalid, it throws an ArgumentException.
- **UI Changes:** Exposed the Server Address field in Server Mode (previously hidden) and relabeled it to "Interface:" to allow users to specify the binding address (defaulting to 127.0.0.1).

---
*PR created automatically by Jules for task [13845135126283658001](https://jules.google.com/task/13845135126283658001) started by @nokkies*