### PR TITLE
⚡ Optimize TrendCoordinator with Request Grouping

### DIFF
--- a/ModbusForge.Tests/Coordinators/TrendCoordinatorTests.cs
+++ b/ModbusForge.Tests/Coordinators/TrendCoordinatorTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ModbusForge.Models;
+using ModbusForge.Services;
+using ModbusForge.ViewModels.Coordinators;
+using Xunit;
+
+namespace ModbusForge.Tests.Coordinators
+{
+    public class TrendCoordinatorTests
+    {
+        private readonly Mock<IModbusService> _clientServiceMock;
+        private readonly Mock<IModbusService> _serverServiceMock;
+        private readonly Mock<ITrendLogger> _trendLoggerMock;
+        private readonly Mock<ILogger<TrendCoordinator>> _loggerMock;
+        private readonly TrendCoordinator _coordinator;
+
+        public TrendCoordinatorTests()
+        {
+            _clientServiceMock = new Mock<IModbusService>();
+            _serverServiceMock = new Mock<IModbusService>();
+            _trendLoggerMock = new Mock<ITrendLogger>();
+            _loggerMock = new Mock<ILogger<TrendCoordinator>>();
+
+            _coordinator = new TrendCoordinator(
+                _clientServiceMock.Object,
+                _serverServiceMock.Object,
+                _trendLoggerMock.Object,
+                _loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task ProcessTrendSamplingAsync_ShouldGroupContiguousRequests()
+        {
+            // Arrange
+            var entries = new List<CustomEntry>();
+            for (int i = 0; i < 10; i++)
+            {
+                entries.Add(new CustomEntry
+                {
+                    Name = $"Entry{i}",
+                    Address = i + 1, // 1-based address: 1, 2, ..., 10
+                    Type = "uint",
+                    Area = "HoldingRegister",
+                    Trend = true
+                });
+            }
+
+            // Setup mock to return an array of 10 ushorts (for addresses 1 to 10)
+            ushort[] returnData = Enumerable.Range(1, 10).Select(i => (ushort)i).ToArray();
+
+            _clientServiceMock
+                .Setup(x => x.ReadHoldingRegistersAsync(1, 1, 10))
+                .ReturnsAsync(returnData);
+
+            bool monitorEnabled = true;
+
+            // Act
+            await _coordinator.ProcessTrendSamplingAsync(
+                entries,
+                unitId: 1,
+                isServerMode: false,
+                setGlobalMonitorEnabled: val => monitorEnabled = val);
+
+            // Assert
+            // Should call ReadHoldingRegistersAsync EXACTLY ONCE with start=1, count=10
+            _clientServiceMock.Verify(
+                x => x.ReadHoldingRegistersAsync(1, 1, 10),
+                Times.Once,
+                "Should group 10 contiguous registers into a single read request");
+
+            // Also verify that individual values were updated and published
+            // Entry 1 (address 1) should have value 1
+            // Entry 10 (address 10) should have value 10
+            _trendLoggerMock.Verify(x => x.Publish("HoldingRegister:1", 1.0, It.IsAny<DateTime>()), Times.Once);
+            _trendLoggerMock.Verify(x => x.Publish("HoldingRegister:10", 10.0, It.IsAny<DateTime>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessTrendSamplingAsync_ShouldSplitRequestsWithLargeGap()
+        {
+            // Arrange
+            var entries = new List<CustomEntry>
+            {
+                new CustomEntry { Address = 1, Type = "uint", Area = "HoldingRegister", Trend = true },
+                new CustomEntry { Address = 100, Type = "uint", Area = "HoldingRegister", Trend = true } // Gap > 10
+            };
+
+            _clientServiceMock
+                .Setup(x => x.ReadHoldingRegistersAsync(1, 1, 1))
+                .ReturnsAsync(new ushort[] { 1 });
+
+            _clientServiceMock
+                .Setup(x => x.ReadHoldingRegistersAsync(1, 100, 1))
+                .ReturnsAsync(new ushort[] { 100 });
+
+            // Act
+            await _coordinator.ProcessTrendSamplingAsync(
+                entries,
+                unitId: 1,
+                isServerMode: false,
+                setGlobalMonitorEnabled: _ => { });
+
+            // Assert
+            _clientServiceMock.Verify(x => x.ReadHoldingRegistersAsync(1, 1, 1), Times.Once);
+            _clientServiceMock.Verify(x => x.ReadHoldingRegistersAsync(1, 100, 1), Times.Once);
+            _clientServiceMock.Verify(x => x.ReadHoldingRegistersAsync(It.IsAny<byte>(), It.IsAny<int>(), It.IsAny<int>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task ProcessTrendSamplingAsync_ShouldHandleMixedTypesInChunk()
+        {
+             // Arrange
+            var entries = new List<CustomEntry>
+            {
+                new CustomEntry { Address = 10, Type = "uint", Area = "HoldingRegister", Trend = true }, // Size 1
+                new CustomEntry { Address = 11, Type = "real", Area = "HoldingRegister", Trend = true }  // Size 2 (11, 12)
+            };
+            // Total range: 10 to 12. Count = 3.
+
+            // Mock return data:
+            // 10: 55
+            // 11-12: float 123.45 -> (low, high) or (high, low).
+            // DataTypeConverter.ToSingle(u1, u2). Assuming implementation uses (u1 | u2<<16) or similar.
+            // Let's rely on mapping.
+
+            _clientServiceMock
+                .Setup(x => x.ReadHoldingRegistersAsync(1, 10, 3))
+                .ReturnsAsync(new ushort[] { 55, 0, 0 }); // Just dummy data
+
+            // Act
+             await _coordinator.ProcessTrendSamplingAsync(
+                entries,
+                unitId: 1,
+                isServerMode: false,
+                setGlobalMonitorEnabled: _ => { });
+
+             // Assert
+             _clientServiceMock.Verify(x => x.ReadHoldingRegistersAsync(1, 10, 3), Times.Once);
+        }
+    }
+}

--- a/ModbusForge/App.xaml.cs
+++ b/ModbusForge/App.xaml.cs
@@ -84,7 +84,12 @@ namespace ModbusForge
             services.AddSingleton<ConnectionCoordinator>();
             services.AddSingleton<RegisterCoordinator>();
             services.AddSingleton<CustomEntryCoordinator>();
-            services.AddSingleton<TrendCoordinator>();
+            services.AddSingleton<TrendCoordinator>(provider => new TrendCoordinator(
+                provider.GetRequiredService<ModbusTcpService>(),
+                provider.GetRequiredService<ModbusServerService>(),
+                provider.GetRequiredService<ITrendLogger>(),
+                provider.GetRequiredService<ILogger<TrendCoordinator>>()
+            ));
             services.AddSingleton<ConfigurationCoordinator>();
             
             // Register ViewModels

--- a/ModbusForge/ViewModels/Coordinators/TrendCoordinator.cs
+++ b/ModbusForge/ViewModels/Coordinators/TrendCoordinator.cs
@@ -17,15 +17,15 @@ namespace ModbusForge.ViewModels.Coordinators
     /// </summary>
     public class TrendCoordinator
     {
-        private readonly ModbusTcpService _clientService;
-        private readonly ModbusServerService _serverService;
+        private readonly IModbusService _clientService;
+        private readonly IModbusService _serverService;
         private readonly ITrendLogger _trendLogger;
         private readonly ILogger<TrendCoordinator> _logger;
         private bool _isTrending;
 
         public TrendCoordinator(
-            ModbusTcpService clientService,
-            ModbusServerService serverService,
+            IModbusService clientService,
+            IModbusService serverService,
             ITrendLogger trendLogger,
             ILogger<TrendCoordinator> logger)
         {
@@ -46,58 +46,28 @@ namespace ModbusForge.ViewModels.Coordinators
         {
             if (_isTrending) return;
 
-            var snapshot = trendEntries.ToList();
+            var snapshot = trendEntries.Where(ce => !string.Equals(ce.Type, "string", StringComparison.OrdinalIgnoreCase)).ToList();
             if (snapshot.Count == 0) return;
 
             _isTrending = true;
             try
             {
                 var now = DateTime.UtcNow;
+                int totalEntries = snapshot.Count;
+                int successCount = 0;
                 int errorCount = 0;
 
-                foreach (var ce in snapshot)
+                var groups = snapshot.GroupBy(ce => (ce.Area ?? "HoldingRegister").ToLowerInvariant());
+
+                foreach (var group in groups)
                 {
-                    try
-                    {
-                        var val = await ReadValueForTrendAsync(ce, unitId, isServerMode);
-                        if (val.HasValue)
-                        {
-                            _trendLogger.Publish(GetTrendKey(ce), val.Value, now);
-                            
-                            // Update display value
-                            var area = (ce.Area ?? "HoldingRegister").ToLowerInvariant();
-                            var type = (ce.Type ?? "uint").ToLowerInvariant();
-                            string display;
-                            
-                            if (area == "coil" || area == "discreteinput")
-                            {
-                                display = val.Value != 0.0 ? "1" : "0";
-                            }
-                            else if (type == "real")
-                            {
-                                display = val.Value.ToString("G9", CultureInfo.InvariantCulture);
-                            }
-                            else if (type == "int")
-                            {
-                                display = ((short)val.Value).ToString(CultureInfo.InvariantCulture);
-                            }
-                            else
-                            {
-                                display = ((ushort)val.Value).ToString(CultureInfo.InvariantCulture);
-                            }
-                            
-                            ce.Value = display;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogDebug(ex, "Trend read failed for {Area} {Address}", ce.Area, ce.Address);
-                        errorCount++;
-                    }
+                    await ProcessAreaAsync(group.Key, group, unitId, isServerMode, now,
+                        onSuccess: () => successCount++,
+                        onError: () => errorCount++);
                 }
 
                 // If all trend reads failed, disable monitoring and show error
-                if (errorCount > 0 && errorCount == snapshot.Count)
+                if (errorCount > 0 && successCount == 0)
                 {
                     setGlobalMonitorEnabled(false);
                     MessageBox.Show(
@@ -113,12 +83,230 @@ namespace ModbusForge.ViewModels.Coordinators
             }
         }
 
+        private async Task ProcessAreaAsync(
+            string area,
+            IEnumerable<CustomEntry> entries,
+            byte unitId,
+            bool isServerMode,
+            DateTime now,
+            Action onSuccess,
+            Action onError)
+        {
+            var service = isServerMode ? _serverService : _clientService;
+            var sorted = entries.OrderBy(e => e.Address).ToList();
+            var chunks = CreateChunks(sorted);
+
+            foreach (var chunk in chunks)
+            {
+                try
+                {
+                    await ReadChunkAsync(area, chunk, service, unitId, now);
+                    foreach (var _ in chunk) onSuccess();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Trend read failed for chunk in {Area}", area);
+                    // If a chunk fails, try to fallback to individual reads?
+                    // For now, assume chunk failure means connection issue or invalid range,
+                    // which likely affects individual reads too.
+                    // But to be safe and consistent with previous behavior (where one bad entry didn't stop others),
+                    // we could try falling back. However, existing code didn't group, so one bad entry just failed that one.
+                    // If we group, one bad entry (e.g. illegal address) will fail the whole chunk.
+                    // This is a trade-off. To be robust, we should try individual read on failure.
+
+                    // Fallback to individual reads
+                    foreach (var entry in chunk)
+                    {
+                        try
+                        {
+                            var val = await ReadValueForTrendAsync(entry, unitId, isServerMode);
+                            if (val.HasValue)
+                            {
+                                UpdateEntry(entry, val.Value, now);
+                                onSuccess();
+                            }
+                            else
+                            {
+                                // Should be rare to get null without exception if connected
+                                onError();
+                            }
+                        }
+                        catch (Exception innerEx)
+                        {
+                            _logger.LogDebug(innerEx, "Individual fallback failed for {Area} {Address}", entry.Area, entry.Address);
+                            onError();
+                        }
+                    }
+                }
+            }
+        }
+
+        private List<List<CustomEntry>> CreateChunks(List<CustomEntry> sortedEntries)
+        {
+            var chunks = new List<List<CustomEntry>>();
+            if (sortedEntries.Count == 0) return chunks;
+
+            var currentChunk = new List<CustomEntry>();
+            currentChunk.Add(sortedEntries[0]);
+
+            int chunkStart = sortedEntries[0].Address;
+            int chunkEnd = chunkStart + GetSize(sortedEntries[0]);
+
+            for (int i = 1; i < sortedEntries.Count; i++)
+            {
+                var entry = sortedEntries[i];
+                int entryStart = entry.Address;
+                int entryEnd = entryStart + GetSize(entry);
+
+                int potentialNewEnd = Math.Max(chunkEnd, entryEnd);
+                int potentialCount = potentialNewEnd - chunkStart;
+
+                // Allow gap of up to 10 registers/coils. Reading 10 extra is cheap compared to new request.
+                // Modbus frame overhead ~10-20 bytes + RTT.
+                bool gapOk = (entryStart - chunkEnd) <= 10;
+                // Max count: 120 (safe margin below 125/253 limits)
+                bool countOk = potentialCount <= 120;
+
+                if (gapOk && countOk)
+                {
+                    currentChunk.Add(entry);
+                    chunkEnd = potentialNewEnd;
+                }
+                else
+                {
+                    chunks.Add(currentChunk);
+                    currentChunk = new List<CustomEntry>();
+                    currentChunk.Add(entry);
+                    chunkStart = entryStart;
+                    chunkEnd = entryEnd;
+                }
+            }
+            chunks.Add(currentChunk);
+            return chunks;
+        }
+
+        private int GetSize(CustomEntry entry)
+        {
+            var type = (entry.Type ?? "uint").ToLowerInvariant();
+            if (type == "real" || type == "float") return 2;
+            return 1;
+        }
+
+        private async Task ReadChunkAsync(
+            string area,
+            List<CustomEntry> chunk,
+            IModbusService service,
+            byte unitId,
+            DateTime now)
+        {
+            if (chunk.Count == 0) return;
+
+            int startAddress = chunk[0].Address;
+            int endAddress = chunk.Max(e => e.Address + GetSize(e));
+            int count = endAddress - startAddress;
+
+            if (area == "holdingregister")
+            {
+                var data = await service.ReadHoldingRegistersAsync(unitId, startAddress, count);
+                if (data == null) throw new Exception("Read returned null");
+                foreach (var entry in chunk)
+                {
+                    int offset = entry.Address - startAddress;
+                    double? val = ExtractRegisterValue(entry, data, offset);
+                    if (val.HasValue) UpdateEntry(entry, val.Value, now);
+                }
+            }
+            else if (area == "inputregister")
+            {
+                var data = await service.ReadInputRegistersAsync(unitId, startAddress, count);
+                if (data == null) throw new Exception("Read returned null");
+                foreach (var entry in chunk)
+                {
+                    int offset = entry.Address - startAddress;
+                    double? val = ExtractRegisterValue(entry, data, offset);
+                    if (val.HasValue) UpdateEntry(entry, val.Value, now);
+                }
+            }
+            else if (area == "coil")
+            {
+                var data = await service.ReadCoilsAsync(unitId, startAddress, count);
+                if (data == null) throw new Exception("Read returned null");
+                foreach (var entry in chunk)
+                {
+                    int offset = entry.Address - startAddress;
+                    double? val = (offset < data.Length) ? (data[offset] ? 1.0 : 0.0) : null;
+                    if (val.HasValue) UpdateEntry(entry, val.Value, now);
+                }
+            }
+            else if (area == "discreteinput")
+            {
+                var data = await service.ReadDiscreteInputsAsync(unitId, startAddress, count);
+                if (data == null) throw new Exception("Read returned null");
+                foreach (var entry in chunk)
+                {
+                    int offset = entry.Address - startAddress;
+                    double? val = (offset < data.Length) ? (data[offset] ? 1.0 : 0.0) : null;
+                    if (val.HasValue) UpdateEntry(entry, val.Value, now);
+                }
+            }
+        }
+
+        private double? ExtractRegisterValue(CustomEntry entry, ushort[] data, int offset)
+        {
+            if (offset < 0 || offset >= data.Length) return null;
+
+            var type = (entry.Type ?? "uint").ToLowerInvariant();
+
+            if (type == "real")
+            {
+                if (offset + 1 >= data.Length) return null;
+                return DataTypeConverter.ToSingle(data[offset], data[offset + 1]);
+            }
+            else if (type == "int")
+            {
+                return (double)unchecked((short)data[offset]);
+            }
+            else // uint
+            {
+                return (double)data[offset];
+            }
+        }
+
+        private void UpdateEntry(CustomEntry ce, double val, DateTime now)
+        {
+             _trendLogger.Publish(GetTrendKey(ce), val, now);
+
+            var area = (ce.Area ?? "HoldingRegister").ToLowerInvariant();
+            var type = (ce.Type ?? "uint").ToLowerInvariant();
+            string display;
+
+            if (area == "coil" || area == "discreteinput")
+            {
+                display = val != 0.0 ? "1" : "0";
+            }
+            else if (type == "real")
+            {
+                display = val.ToString("G9", CultureInfo.InvariantCulture);
+            }
+            else if (type == "int")
+            {
+                display = ((short)val).ToString(CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                display = ((ushort)val).ToString(CultureInfo.InvariantCulture);
+            }
+
+            ce.Value = display;
+        }
+
         /// <summary>
         /// Reads a value from a custom entry for trend logging.
+        /// (Kept for fallback logic)
         /// </summary>
         private async Task<double?> ReadValueForTrendAsync(CustomEntry entry, byte unitId, bool isServerMode)
         {
-            var service = isServerMode ? (IModbusService)_serverService : _clientService;
+            var service = isServerMode ? _serverService : _clientService;
             var area = (entry.Area ?? "HoldingRegister").ToLowerInvariant();
 
             switch (area)
@@ -167,7 +355,6 @@ namespace ModbusForge.ViewModels.Coordinators
             }
             else if (type == "string")
             {
-                // Not a numeric trend; skip
                 return null;
             }
             else // uint


### PR DESCRIPTION
This PR optimizes the `TrendCoordinator` to resolve the N+1 query performance issue.
Previously, `ProcessTrendSamplingAsync` would iterate through each `CustomEntry` and issue a separate Modbus request, causing significant latency and network overhead when monitoring many points.

**Changes:**
- Implemented request grouping: `CustomEntry` items are now grouped by Area and sorted by Address.
- Created chunks of contiguous addresses (with a max gap of 10 registers and max count of 120 registers) to be read in a single Modbus request.
- Added `ProcessAreaAsync` and `ReadChunkAsync` to handle the batch reading and distribution of values back to the `CustomEntry` objects.
- Added a fallback mechanism: If a chunk read fails (e.g., due to an invalid address in the range), the code falls back to reading each entry in the chunk individually, ensuring robustness.
- Refactored `TrendCoordinator` constructor to accept `IModbusService` interfaces instead of concrete types, enabling unit testing with mocks.
- Updated `App.xaml.cs` to correctly register `TrendCoordinator` with the concrete `ModbusTcpService` and `ModbusServerService` instances.
- Added `TrendCoordinatorTests.cs` to verify the optimization (ensuring 1 request instead of 10 for contiguous entries) and handle edge cases like gaps and mixed types.

**Performance Impact:**
- For 100 contiguous registers, the number of Modbus requests is reduced from 100 to 1.
- Significantly reduces the time to update trend data, allowing for faster sampling rates and less UI stutter.

---
*PR created automatically by Jules for task [3966776821999004323](https://jules.google.com/task/3966776821999004323) started by @nokkies*