### PR TITLE
⚡ Implement IAsyncDisposable in ModbusTcpService to avoid blocking Dispose

### DIFF
--- a/ModbusForge.Tests/Services/ModbusTcpServicePerformanceTests.cs
+++ b/ModbusForge.Tests/Services/ModbusTcpServicePerformanceTests.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ModbusForge.Services;
+using Xunit;
+
+namespace ModbusForge.Tests.Services
+{
+    public class ModbusTcpServicePerformanceTests
+    {
+        [Fact]
+        public async Task DisposeAsync_DoesNotBlockCallingThread_WhenLockIsHeld()
+        {
+            // Arrange
+            var mockLogger = new Mock<ILogger<ModbusTcpService>>();
+            var service = new ModbusTcpService(mockLogger.Object);
+
+            // Use reflection to get the private _ioLock
+            var ioLockField = typeof(ModbusTcpService).GetField("_ioLock", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(ioLockField);
+            var ioLock = (SemaphoreSlim)ioLockField.GetValue(service)!;
+
+            // Acquire the lock on the current thread
+            await ioLock.WaitAsync();
+
+            try
+            {
+                // Act
+                var sw = Stopwatch.StartNew();
+
+                // DisposeAsync should return a task that is not completed because it's waiting for the lock
+                var disposeTask = service.DisposeAsync().AsTask();
+
+                // Verify it hasn't finished yet (it's waiting for the lock)
+                // We use a small delay to ensure the task had a chance to run up to the await
+                await Task.Delay(100);
+                Assert.False(disposeTask.IsCompleted);
+
+                // Release the lock
+                ioLock.Release();
+
+                // Now it should complete
+                await disposeTask;
+                sw.Stop();
+
+                // Assert
+                Assert.True(sw.ElapsedMilliseconds >= 100, "DisposeAsync should have waited for the lock release");
+            }
+            finally
+            {
+                // Cleanup if needed (though ioLock is disposed by service.DisposeAsync)
+            }
+        }
+
+        [Fact]
+        public async Task Dispose_BlocksCallingThread_WhenLockIsHeld()
+        {
+            // Arrange
+            var mockLogger = new Mock<ILogger<ModbusTcpService>>();
+            var service = new ModbusTcpService(mockLogger.Object);
+
+            var ioLockField = typeof(ModbusTcpService).GetField("_ioLock", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(ioLockField);
+            var ioLock = (SemaphoreSlim)ioLockField.GetValue(service)!;
+
+            await ioLock.WaitAsync();
+
+            try
+            {
+                // Act
+                var sw = Stopwatch.StartNew();
+
+                // Run Dispose in a separate task and check if it blocks
+                var disposeTask = Task.Run(() => service.Dispose());
+
+                await Task.Delay(100);
+                Assert.False(disposeTask.IsCompleted);
+
+                ioLock.Release();
+                await disposeTask;
+                sw.Stop();
+
+                // Assert
+                Assert.True(sw.ElapsedMilliseconds >= 100);
+            }
+            finally
+            {
+            }
+        }
+    }
+}

--- a/ModbusForge/Services/IModbusService.cs
+++ b/ModbusForge/Services/IModbusService.cs
@@ -32,7 +32,7 @@ namespace ModbusForge.Services
         }
     }
 
-    public interface IModbusService : IDisposable
+    public interface IModbusService : IDisposable, IAsyncDisposable
     {
         bool IsConnected { get; }
         

--- a/ModbusForge/Services/ModbusServerService.cs
+++ b/ModbusForge/Services/ModbusServerService.cs
@@ -333,6 +333,29 @@ namespace ModbusForge.Services
             GC.SuppressFinalize(this);
         }
 
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (!_disposed)
+            {
+                try
+                {
+                    await DisconnectAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error during DisposeAsync");
+                }
+                _disposed = true;
+            }
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/ModbusForge/Services/ModbusTcpService.cs
+++ b/ModbusForge/Services/ModbusTcpService.cs
@@ -338,12 +338,41 @@ namespace ModbusForge.Services
             GC.SuppressFinalize(this);
         }
 
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (!_disposed)
+            {
+                // Use async wait to avoid blocking the calling thread
+                await _ioLock.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    _client?.Dispose();
+                    _tcpClient?.Close();
+                }
+                finally
+                {
+                    _ioLock.Release();
+                    _ioLock.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
             {
                 if (disposing)
                 {
+                    // For synchronous dispose, we have to wait synchronously.
+                    // Callers are encouraged to use DisposeAsync to avoid blocking.
                     _ioLock.Wait();
                     try
                     {


### PR DESCRIPTION
### 💡 What:
Implemented `IAsyncDisposable` across the Modbus service hierarchy (`IModbusService`, `ModbusTcpService`, `ModbusServerService`).

### 🎯 Why:
The existing `Dispose` implementation in `ModbusTcpService` used a blocking `_ioLock.Wait()`. In a WPF application, if `Dispose` is called from the UI thread while a background Modbus operation is holding the lock, the UI thread would freeze until the operation completed. Implementing `IAsyncDisposable` allows for non-blocking asynchronous cleanup.

### 📊 Measured Improvement:
- **Baseline:** `Dispose()` blocks the calling thread if `_ioLock` is held by another task.
- **Improvement:** `DisposeAsync()` awaits the lock asynchronously, allowing the calling thread (e.g., UI thread) to remain responsive or be returned to the thread pool while waiting.
- **Verification:** New unit tests in `ModbusTcpServicePerformanceTests.cs` use reflection to hold the lock and verify that `DisposeAsync()` does not block the calling thread, whereas the synchronous `Dispose()` does.


---
*PR created automatically by Jules for task [12399826887175238731](https://jules.google.com/task/12399826887175238731) started by @nokkies*