### PR TITLE
🧹 Refactor ScriptRule to use ObservableObject

### DIFF
--- a/ModbusForge/Models/ScriptRule.cs
+++ b/ModbusForge/Models/ScriptRule.cs
@@ -1,134 +1,56 @@
-using System;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ModbusForge.Models
 {
     /// <summary>
     /// Represents a script rule that can automate Modbus operations based on conditions
     /// </summary>
-    public class ScriptRule : INotifyPropertyChanged
+    public partial class ScriptRule : ObservableObject
     {
+        [ObservableProperty]
         private string _name = "";
+
+        [ObservableProperty]
         private bool _enabled = true;
+
+        [ObservableProperty]
         private string _conditionType = "RegisterValue"; // RegisterValue, CoilsState, TimeBased
+
+        [ObservableProperty]
         private int _triggerAddress = 1;
+
+        [ObservableProperty]
         private string _triggerArea = "HoldingRegister"; // HoldingRegister, Coil, InputRegister, DiscreteInput
+
+        [ObservableProperty]
         private string _triggerOperator = "Equals"; // Equals, NotEquals, GreaterThan, LessThan, GreaterThanOrEqual, LessThanOrEqual
+
+        [ObservableProperty]
         private string _triggerValue = "0";
+
+        [ObservableProperty]
         private string _actionType = "SetRegister"; // SetRegister, SetCoil, Delay, LogMessage
+
+        [ObservableProperty]
         private int _actionAddress = 1;
+
+        [ObservableProperty]
         private string _actionArea = "HoldingRegister";
+
+        [ObservableProperty]
         private string _actionValue = "1";
+
+        [ObservableProperty]
         private int _delayMs = 1000;
+
+        [ObservableProperty]
         private string _logMessage = "Rule triggered";
+
+        [ObservableProperty]
         private bool _oneTime = false;
+
+        [ObservableProperty]
         private bool _triggered = false;
-
-        public string Name
-        {
-            get => _name;
-            set => SetProperty(ref _name, value);
-        }
-
-        public bool Enabled
-        {
-            get => _enabled;
-            set => SetProperty(ref _enabled, value);
-        }
-
-        public string ConditionType
-        {
-            get => _conditionType;
-            set => SetProperty(ref _conditionType, value);
-        }
-
-        public int TriggerAddress
-        {
-            get => _triggerAddress;
-            set => SetProperty(ref _triggerAddress, value);
-        }
-
-        public string TriggerArea
-        {
-            get => _triggerArea;
-            set => SetProperty(ref _triggerArea, value);
-        }
-
-        public string TriggerOperator
-        {
-            get => _triggerOperator;
-            set => SetProperty(ref _triggerOperator, value);
-        }
-
-        public string TriggerValue
-        {
-            get => _triggerValue;
-            set => SetProperty(ref _triggerValue, value);
-        }
-
-        public string ActionType
-        {
-            get => _actionType;
-            set => SetProperty(ref _actionType, value);
-        }
-
-        public int ActionAddress
-        {
-            get => _actionAddress;
-            set => SetProperty(ref _actionAddress, value);
-        }
-
-        public string ActionArea
-        {
-            get => _actionArea;
-            set => SetProperty(ref _actionArea, value);
-        }
-
-        public string ActionValue
-        {
-            get => _actionValue;
-            set => SetProperty(ref _actionValue, value);
-        }
-
-        public int DelayMs
-        {
-            get => _delayMs;
-            set => SetProperty(ref _delayMs, value);
-        }
-
-        public string LogMessage
-        {
-            get => _logMessage;
-            set => SetProperty(ref _logMessage, value);
-        }
-
-        public bool OneTime
-        {
-            get => _oneTime;
-            set => SetProperty(ref _oneTime, value);
-        }
-
-        public bool Triggered
-        {
-            get => _triggered;
-            set => SetProperty(ref _triggered, value);
-        }
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-
-        protected bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
-        {
-            if (Equals(field, value)) return false;
-            field = value;
-            OnPropertyChanged(propertyName);
-            return true;
-        }
-
-        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
 
         /// <summary>
         /// Creates a copy of this rule


### PR DESCRIPTION
I have refactored the `ScriptRule` model in `ModbusForge/Models/ScriptRule.cs` to use `ObservableObject` and `[ObservableProperty]` from the `CommunityToolkit.Mvvm` library. This change reduces boilerplate code while maintaining full property functionality and compatibility with existing bindings. 

Key changes:
- Changed `ScriptRule` to inherit from `ObservableObject`.
- Marked the class as `partial` to enable source generation.
- Decorated all private fields with `[ObservableProperty]`.
- Removed manual `INotifyPropertyChanged` implementation and manual property definitions.
- Verified that all 15 original properties are correctly handled and that methods like `Clone()` and `GetDescription()` remain functional.

Verification:
- Manual code review confirmed property name consistency.
- Build and tests were attempted but skipped due to environment-specific NuGet restore issues (no internet access to nuget.org). The refactoring follows the same pattern already successfully used in other parts of the codebase (e.g., `MainViewModel.cs`, `ScriptCommand.cs`).

---
*PR created automatically by Jules for task [17120123331546931019](https://jules.google.com/task/17120123331546931019) started by @nokkies*