### PR TITLE
🔒 [security fix] Fix potential DoS via large file reading

### DIFF
--- a/ModbusForge.Tests/Services/CustomEntryServiceTests.cs
+++ b/ModbusForge.Tests/Services/CustomEntryServiceTests.cs
@@ -1,0 +1,129 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModbusForge.Models;
+using ModbusForge.Services;
+using Moq;
+using Xunit;
+
+namespace ModbusForge.Tests.Services
+{
+    public class CustomEntryServiceTests
+    {
+        private readonly Mock<IFileDialogService> _mockFileDialogService;
+        private readonly Mock<ILogger<CustomEntryService>> _mockLogger;
+        private readonly CustomEntryService _service;
+
+        public CustomEntryServiceTests()
+        {
+            _mockFileDialogService = new Mock<IFileDialogService>();
+            _mockLogger = new Mock<ILogger<CustomEntryService>>();
+            _service = new CustomEntryService(_mockFileDialogService.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task LoadCustomAsync_ReturnsNull_WhenUserCancels()
+        {
+            // Arrange
+            _mockFileDialogService.Setup(s => s.ShowOpenFileDialog(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string)null);
+
+            // Act
+            var result = await _service.LoadCustomAsync();
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task LoadCustomAsync_ThrowsInvalidDataException_WhenFileTooLarge()
+        {
+            // Arrange
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                // Create a file larger than 2MB
+                using (var fs = new FileStream(tempFile, FileMode.OpenOrCreate))
+                {
+                    fs.SetLength(3 * 1024 * 1024); // 3MB
+                }
+
+                _mockFileDialogService.Setup(s => s.ShowOpenFileDialog(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns(tempFile);
+
+                // Act & Assert
+                var exception = await Assert.ThrowsAsync<InvalidDataException>(() => _service.LoadCustomAsync());
+                Assert.Contains("too large", exception.Message);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public async Task LoadCustomAsync_LoadsValidFile_Successfully()
+        {
+            // Arrange
+            var tempFile = Path.GetTempFileName();
+            var entries = new[]
+            {
+                new { Name = "Test", Address = 1, Type = "uint", Value = "100", Area = "HoldingRegister" }
+            };
+            var json = JsonSerializer.Serialize(entries);
+            await File.WriteAllTextAsync(tempFile, json);
+
+            try
+            {
+                _mockFileDialogService.Setup(s => s.ShowOpenFileDialog(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns(tempFile);
+
+                // Act
+                var result = await _service.LoadCustomAsync();
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Single(result);
+                Assert.Equal("Test", result[0].Name);
+                Assert.Equal(1, result[0].Address);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public async Task SaveCustomAsync_SavesFile_Successfully()
+        {
+            // Arrange
+            var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var entries = new ObservableCollection<CustomEntry>
+            {
+                new CustomEntry { Name = "SaveTest", Address = 10, Value = "50" }
+            };
+
+            _mockFileDialogService.Setup(s => s.ShowSaveFileDialog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(tempFile);
+
+            try
+            {
+                // Act
+                await _service.SaveCustomAsync(entries);
+
+                // Assert
+                Assert.True(File.Exists(tempFile));
+                var json = await File.ReadAllTextAsync(tempFile);
+                var doc = JsonDocument.Parse(json);
+                Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+                Assert.Equal("SaveTest", doc.RootElement[0].GetProperty("Name").GetString());
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+    }
+}

--- a/ModbusForge/ScriptEditorWindow.xaml.cs
+++ b/ModbusForge/ScriptEditorWindow.xaml.cs
@@ -169,7 +169,9 @@ public partial class ScriptEditorWindow : MetroWindow, INotifyPropertyChanged
         OutputLog.Items.Clear();
     }
 
-    private void SaveScript_Click(object sender, RoutedEventArgs e)
+    private const long MaxFileSize = 1 * 1024 * 1024; // 1MB limit for scripts
+
+    private async void SaveScript_Click(object sender, RoutedEventArgs e)
     {
         var dlg = new SaveFileDialog
         {
@@ -202,8 +204,9 @@ public partial class ScriptEditorWindow : MetroWindow, INotifyPropertyChanged
                     }).ToList()
                 };
 
-                var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
-                File.WriteAllText(dlg.FileName, json);
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                using var stream = File.Create(dlg.FileName);
+                await JsonSerializer.SerializeAsync(stream, data, options);
                 MessageBox.Show("Script saved successfully.", "Save Script", MessageBoxButton.OK, MessageBoxImage.Information);
             }
             catch (Exception ex)
@@ -213,7 +216,7 @@ public partial class ScriptEditorWindow : MetroWindow, INotifyPropertyChanged
         }
     }
 
-    private void LoadScript_Click(object sender, RoutedEventArgs e)
+    private async void LoadScript_Click(object sender, RoutedEventArgs e)
     {
         var dlg = new OpenFileDialog
         {
@@ -224,8 +227,16 @@ public partial class ScriptEditorWindow : MetroWindow, INotifyPropertyChanged
         {
             try
             {
-                var json = File.ReadAllText(dlg.FileName);
-                var data = JsonSerializer.Deserialize<ScriptData>(json);
+                var fileInfo = new FileInfo(dlg.FileName);
+                if (fileInfo.Length > MaxFileSize)
+                {
+                    MessageBox.Show($"The selected file is too large (max {MaxFileSize / 1024 / 1024}MB).",
+                        "Load Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
+
+                using var stream = File.OpenRead(dlg.FileName);
+                var data = await JsonSerializer.DeserializeAsync<ScriptData>(stream);
 
                 if (data != null)
                 {

--- a/ModbusForge/Services/CustomEntryService.cs
+++ b/ModbusForge/Services/CustomEntryService.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.Logging;
 using ModbusForge.Models;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Text.Json;
@@ -10,22 +13,32 @@ namespace ModbusForge.Services
     public class CustomEntryService : ICustomEntryService
     {
         private readonly IFileDialogService _fileDialogService;
+        private readonly ILogger<CustomEntryService> _logger;
+        private const long MaxFileSize = 2 * 1024 * 1024; // 2MB limit for custom entries
 
-        public CustomEntryService(IFileDialogService fileDialogService)
+        public CustomEntryService(IFileDialogService fileDialogService, ILogger<CustomEntryService> logger)
         {
             _fileDialogService = fileDialogService;
+            _logger = logger;
         }
 
-        public async Task<ObservableCollection<CustomEntry>> LoadCustomAsync()
+        public async Task<ObservableCollection<CustomEntry>?> LoadCustomAsync()
         {
             var path = _fileDialogService.ShowOpenFileDialog("Load Custom Entries", "JSON files (*.json)|*.json|All files (*.*)|*.*");
             if (path is null)
             {
-                return new ObservableCollection<CustomEntry>();
+                return null;
             }
 
-            var json = await File.ReadAllTextAsync(path);
-            using var doc = JsonDocument.Parse(json);
+            var fileInfo = new FileInfo(path);
+            if (fileInfo.Length > MaxFileSize)
+            {
+                _logger.LogError("File {Path} exceeds maximum size of {MaxSize} bytes", path, MaxFileSize);
+                throw new InvalidDataException($"The selected file is too large (max {MaxFileSize / 1024 / 1024}MB).");
+            }
+
+            using var stream = File.OpenRead(path);
+            using var doc = await JsonDocument.ParseAsync(stream);
             var list = new ObservableCollection<CustomEntry>();
             foreach (var item in doc.RootElement.EnumerateArray())
             {
@@ -55,7 +68,7 @@ namespace ModbusForge.Services
                 return;
             }
 
-            var data = new System.Collections.Generic.List<object>();
+            var data = new List<object>();
             foreach (var e in entries)
             {
                 data.Add(new
@@ -72,9 +85,10 @@ namespace ModbusForge.Services
                     e.Trend
                 });
             }
+
             var options = new JsonSerializerOptions { WriteIndented = true };
-            var json = JsonSerializer.Serialize(data, options);
-            await File.WriteAllTextAsync(path, json);
+            using var stream = File.Create(path);
+            await JsonSerializer.SerializeAsync(stream, data, options);
         }
     }
 }

--- a/ModbusForge/Services/ICustomEntryService.cs
+++ b/ModbusForge/Services/ICustomEntryService.cs
@@ -7,6 +7,6 @@ namespace ModbusForge.Services
     public interface ICustomEntryService
     {
         Task SaveCustomAsync(ObservableCollection<CustomEntry> entries);
-        Task<ObservableCollection<CustomEntry>> LoadCustomAsync();
+        Task<ObservableCollection<CustomEntry>?> LoadCustomAsync();
     }
 }

--- a/ModbusForge/ViewModels/Coordinators/ConfigurationCoordinator.cs
+++ b/ModbusForge/ViewModels/Coordinators/ConfigurationCoordinator.cs
@@ -25,6 +25,8 @@ namespace ModbusForge.ViewModels.Coordinators
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
+        private const long MaxFileSize = 5 * 1024 * 1024; // 5MB limit for full configuration
+
         /// <summary>
         /// Saves the complete application configuration to a JSON file.
         /// </summary>
@@ -56,8 +58,9 @@ namespace ModbusForge.ViewModels.Coordinators
                         CustomEntries = customEntries.ToList()
                     };
 
-                    var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
-                    await File.WriteAllTextAsync(dialog.FileName, json);
+                    var options = new JsonSerializerOptions { WriteIndented = true };
+                    using var stream = File.Create(dialog.FileName);
+                    await JsonSerializer.SerializeAsync(stream, config, options);
                     setStatusMessage($"Saved configuration to {Path.GetFileName(dialog.FileName)}");
                 }
             }
@@ -83,8 +86,14 @@ namespace ModbusForge.ViewModels.Coordinators
 
                 if (dialog.ShowDialog() == true)
                 {
-                    var json = await File.ReadAllTextAsync(dialog.FileName);
-                    var config = JsonSerializer.Deserialize<AppConfiguration>(json);
+                    var fileInfo = new FileInfo(dialog.FileName);
+                    if (fileInfo.Length > MaxFileSize)
+                    {
+                        throw new InvalidDataException($"The selected file is too large (max {MaxFileSize / 1024 / 1024}MB).");
+                    }
+
+                    using var stream = File.OpenRead(dialog.FileName);
+                    var config = await JsonSerializer.DeserializeAsync<AppConfiguration>(stream);
 
                     if (config != null)
                     {


### PR DESCRIPTION
This PR addresses a potential Denial of Service (DoS) vulnerability where large JSON files could be used to cause an OutOfMemoryException by loading the entire file into memory as a string.

Key changes:
1.  **Size Limits:** Enforced a maximum file size for all file imports:
    - Custom Entries: 2MB
    - Configuration: 5MB
    - Scripts: 1MB
2.  **Streaming Processing:** Switched from `File.ReadAllTextAsync` + `JsonSerializer.Deserialize(string)` to `File.OpenRead` + `JsonSerializer.DeserializeAsync(stream)`. This avoids double allocation of the file content in memory (once as a string and once in the JSON document/model).
3.  **Improved Error Handling:** Added logging for oversized files and descriptive error messages shown to the user via existing UI mechanisms.
4.  **Tests:** Added unit tests for `CustomEntryService` verifying the size limit enforcement and successful loading of valid files.
5.  **Proactive Fixes:** Applied the same security patterns to `ConfigurationCoordinator` and `ScriptEditorWindow` which exhibited the same vulnerable pattern.

---
*PR created automatically by Jules for task [5225978307752796342](https://jules.google.com/task/5225978307752796342) started by @nokkies*