### PR TITLE
🧪 [Testing Improvement] Add unit tests for ConnectionCoordinator.RunDiagnosticsAsync

### DIFF
--- a/ModbusForge.Tests/Coordinators/ConnectionCoordinatorTests.cs
+++ b/ModbusForge.Tests/Coordinators/ConnectionCoordinatorTests.cs
@@ -152,5 +152,175 @@ namespace ModbusForge.Tests.Coordinators
             Assert.NotNull(statusMessage);
             Assert.False(connectedState);
         }
+
+        [Fact]
+        public async Task RunDiagnosticsAsync_WhenTcpAndModbusOk_ReturnsTrue()
+        {
+            // Arrange
+            string serverAddress = "127.0.0.1";
+            int port = 502;
+            byte unitId = 1;
+            string? statusMessage = null;
+
+            var expectedResult = new ConnectionDiagnosticResult
+            {
+                TcpConnected = true,
+                ModbusResponding = true,
+                TcpLatencyMs = 10,
+                ModbusLatencyMs = 20,
+                LocalEndpoint = "127.0.0.1:12345",
+                RemoteEndpoint = "127.0.0.1:502"
+            };
+
+            _mockClientService.Setup(s => s.RunDiagnosticsAsync(serverAddress, port, unitId))
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _coordinator.RunDiagnosticsAsync(serverAddress, port, unitId, msg => statusMessage = msg);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("TCP: OK, Modbus: OK", statusMessage);
+            _mockClientService.Verify(s => s.RunDiagnosticsAsync(serverAddress, port, unitId), Times.Once);
+            _mockConsoleLogger.Verify(l => l.Log(It.Is<string>(s => s.Contains("OK"))), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task RunDiagnosticsAsync_WhenTcpFails_ReturnsFalse()
+        {
+            // Arrange
+            string serverAddress = "127.0.0.1";
+            int port = 502;
+            byte unitId = 1;
+            string? statusMessage = null;
+
+            var expectedResult = new ConnectionDiagnosticResult
+            {
+                TcpConnected = false,
+                ModbusResponding = false,
+                TcpError = "Connection refused"
+            };
+
+            _mockClientService.Setup(s => s.RunDiagnosticsAsync(serverAddress, port, unitId))
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _coordinator.RunDiagnosticsAsync(serverAddress, port, unitId, msg => statusMessage = msg);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal("TCP: FAIL, Modbus: FAIL", statusMessage);
+            _mockConsoleLogger.Verify(l => l.Log(It.Is<string>(s => s.Contains("Error: Connection refused"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task RunDiagnosticsAsync_WhenModbusFails_ReturnsFalse()
+        {
+            // Arrange
+            string serverAddress = "127.0.0.1";
+            int port = 502;
+            byte unitId = 1;
+            string? statusMessage = null;
+
+            var expectedResult = new ConnectionDiagnosticResult
+            {
+                TcpConnected = true,
+                ModbusResponding = false,
+                ModbusError = "Timeout",
+                TcpLatencyMs = 10,
+                LocalEndpoint = "127.0.0.1:12345",
+                RemoteEndpoint = "127.0.0.1:502"
+            };
+
+            _mockClientService.Setup(s => s.RunDiagnosticsAsync(serverAddress, port, unitId))
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _coordinator.RunDiagnosticsAsync(serverAddress, port, unitId, msg => statusMessage = msg);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal("TCP: OK, Modbus: FAIL", statusMessage);
+            _mockConsoleLogger.Verify(l => l.Log(It.Is<string>(s => s.Contains("Error: Timeout"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task RunDiagnosticsAsync_WhenServiceThrowsException_ReturnsFalse()
+        {
+            // Arrange
+            string serverAddress = "127.0.0.1";
+            int port = 502;
+            byte unitId = 1;
+            string? statusMessage = null;
+
+            var exception = new Exception("Test exception");
+            _mockClientService.Setup(s => s.RunDiagnosticsAsync(serverAddress, port, unitId))
+                .ThrowsAsync(exception);
+
+            // Act
+            var result = await _coordinator.RunDiagnosticsAsync(serverAddress, port, unitId, msg => statusMessage = msg);
+
+            // Assert
+            Assert.False(result);
+            Assert.Contains("Test exception", statusMessage);
+            _mockConsoleLogger.Verify(l => l.Log(It.Is<string>(s => s.Contains("Diagnostics error: Test exception"))), Times.Once);
+
+            // Note: Verifying ILogger is tricky due to extension methods,
+            // but we know it's injected and used based on other log operations.
+            // We just verify it doesn't crash here.
+        }
+
+        [Fact]
+        public async Task RunDiagnosticsAsync_WhenResultIsNull_HandlesNullReferenceException()
+        {
+            // Arrange
+            string serverAddress = "127.0.0.1";
+            int port = 502;
+            byte unitId = 1;
+            string? statusMessage = null;
+
+            // Simulate the service returning null
+            _mockClientService.Setup(s => s.RunDiagnosticsAsync(serverAddress, port, unitId))
+                .ReturnsAsync((ConnectionDiagnosticResult)null!);
+
+            // Act
+            var result = await _coordinator.RunDiagnosticsAsync(serverAddress, port, unitId, msg => statusMessage = msg);
+
+            // Assert
+            Assert.False(result);
+            // It will hit the catch block when it tries to access result.TcpConnected
+            Assert.Contains("Diagnostics error", statusMessage);
+            _mockConsoleLogger.Verify(l => l.Log(It.Is<string>(s => s.Contains("Diagnostics error"))), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task RunDiagnosticsAsync_WhenFailsButErrorStringsNull_DoesNotThrow()
+        {
+            // Arrange
+            string serverAddress = "127.0.0.1";
+            int port = 502;
+            byte unitId = 1;
+            string? statusMessage = null;
+
+            var expectedResult = new ConnectionDiagnosticResult
+            {
+                TcpConnected = false,
+                ModbusResponding = false,
+                TcpError = null!,
+                ModbusError = null!
+            };
+
+            _mockClientService.Setup(s => s.RunDiagnosticsAsync(serverAddress, port, unitId))
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _coordinator.RunDiagnosticsAsync(serverAddress, port, unitId, msg => statusMessage = msg);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal("TCP: FAIL, Modbus: FAIL", statusMessage);
+            // Verify we hit the end of the method successfully
+            _mockConsoleLogger.Verify(l => l.Log("=== Diagnostics Complete ==="), Times.Once);
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `RunDiagnosticsAsync` method in `ModbusForge/ViewModels/Coordinators/ConnectionCoordinator.cs` lacked unit tests. This method delegates connection diagnostics to `_clientService` and formats the results for logging and UI status messages.

📊 **Coverage:** What scenarios are now tested
*   **Success Path:** Verified that when TCP and Modbus tests both pass, the method returns `true`, logs success, and updates the status message to "TCP: OK, Modbus: OK".
*   **TCP Failure:** Verified that when the TCP connection fails, the method returns `false`, logs the TCP error, and updates the status message to "TCP: FAIL, Modbus: FAIL".
*   **Modbus Failure:** Verified that when TCP passes but Modbus fails, the method returns `false`, logs the Modbus error, and updates the status message to "TCP: OK, Modbus: FAIL".
*   **Exception Handling:** Verified that if the underlying service throws an exception, the coordinator catches it, returns `false`, and logs the exception message correctly.
*   **Edge Case - Null Result:** Ensured the method handles a potential `NullReferenceException` gracefully if the service unexpectedly returns `null`, returning `false`.
*   **Edge Case - Missing Error Strings:** Verified that the method does not throw exceptions when a failure occurs but the underlying `TcpError` or `ModbusError` strings are null.

✨ **Result:** The improvement in test coverage
The `RunDiagnosticsAsync` logic within `ConnectionCoordinator` is now fully tested, ensuring that diagnostic results are always processed and reported safely, preventing potential UI crashes from unexpected service outputs.

---
*PR created automatically by Jules for task [5141960806733697848](https://jules.google.com/task/5141960806733697848) started by @nokkies*