### PR TITLE
🔒 Update deprecated NModbus4 dependency to maintained NModbus library

### DIFF
--- a/ModbusForge/ModbusForge.csproj
+++ b/ModbusForge/ModbusForge.csproj
@@ -19,7 +19,7 @@
 
   <!-- Suppress package compatibility warnings for legacy packages -->
   <ItemGroup>
-    <PackageReference Include="NModbus4" Version="2.0.5516.31020" />
+    <PackageReference Include="NModbus" Version="3.0.81" />
     <PackageReference Include="OpenTK" Version="3.3.1" />
     <PackageReference Include="OpenTK.GLWpfControl" Version="3.3.0" />
   </ItemGroup>

--- a/ModbusForge/Services/ModbusServerService.cs
+++ b/ModbusForge/Services/ModbusServerService.cs
@@ -3,8 +3,8 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Modbus.Data;
-using Modbus.Device;
+using NModbus.Data;
+using NModbus;
 using System.Net.Sockets;
 using ModbusForge.Helpers;
 
@@ -12,11 +12,12 @@ namespace ModbusForge.Services
 {
     public class ModbusServerService : IModbusService, IDisposable
     {
-        private ModbusTcpSlave? _slave;
+        private IModbusSlaveNetwork? _slaveNetwork;
         private TcpListener? _listener;
-        private DataStore? _dataStore;
+        private ISlaveDataStore? _dataStore;
         private Task? _listenTask;
         private CancellationTokenSource? _cts;
+        private readonly IModbusFactory _factory = new ModbusFactory();
         private bool _disposed = false;
         private readonly ILogger<ModbusServerService> _logger;
         private volatile bool _isRunning = false;
@@ -46,15 +47,17 @@ namespace ModbusForge.Services
                         throw new InvalidOperationException("Data store not initialized");
 
                     var registers = _dataStore.InputRegisters;
-                    if (startAddress < 1 || count < 0 || startAddress + count - 1 > registers.Count)
+                    // NModbus 3 uses 0-based indexing for limits. Let's just catch out of bounds or read directly.
+                    try
+                    {
+                        var result = registers.ReadPoints((ushort)(startAddress > 0 ? startAddress - 1 : 0), (ushort)count);
+                        _logger.LogDebug($"Successfully read {result.Length} input registers");
+                        return result;
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(startAddress), "Requested range is out of bounds");
-
-                    var result = new ushort[count];
-                    for (int i = 0; i < count; i++)
-                        result[i] = registers[(ushort)(startAddress + i)];
-
-                    _logger.LogDebug($"Successfully read {result.Length} input registers");
-                    return result;
+                    }
                 }
             });
         }
@@ -68,16 +71,20 @@ namespace ModbusForge.Services
             {
                 _logger.LogDebug($"Reading {count} discrete inputs starting at {startAddress} (Unit ID: {unitId})");
 
-                var inputs = _dataStore?.InputDiscretes;
-                if (inputs == null || startAddress < 1 || count < 0 || startAddress + count - 1 > inputs.Count)
+                var inputs = _dataStore?.CoilInputs;
+                if (inputs == null)
+                    throw new InvalidOperationException("Data store not initialized");
+
+                try
+                {
+                    var result = inputs.ReadPoints((ushort)(startAddress > 0 ? startAddress - 1 : 0), (ushort)count);
+                    _logger.LogDebug($"Successfully read {result.Length} discrete inputs");
+                    return result;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
                     throw new ArgumentOutOfRangeException(nameof(startAddress), "Requested discrete input range is out of bounds");
-
-                var result = new bool[count];
-                for (int i = 0; i < count; i++)
-                    result[i] = inputs[(ushort)(startAddress + i)];
-
-                _logger.LogDebug($"Successfully read {result.Length} discrete inputs");
-                return result;
+                }
             });
         }
 
@@ -97,51 +104,31 @@ namespace ModbusForge.Services
                         var endpoint = new IPEndPoint(IPAddress.Any, port == 0 ? DefaultPort : port);
                     
                     // Create data store
-                    _dataStore = new DataStore();
-                    
-                    // Initialize holding registers to support addresses up to 10000
-                    for (int i = 0; i < 10000; i++)
-                    {
-                        _dataStore.HoldingRegisters.Add(0);
-                    }
-                                         
-
-                        // Initialize input registers to support addresses up to 10000
-                        for (int i = 0; i < 10000; i++)
-                    {
-                        _dataStore.InputRegisters.Add(0);
-                    }
-                    
-                    // Initialize coils to support addresses up to 10000
-                    for (int i = 0; i < 10000; i++)
-                    {
-                        _dataStore.CoilDiscretes.Add(false);
-                    }
-                    
-                    // Initialize discrete inputs to support addresses up to 10000
-                    for (int i = 0; i < 10000; i++)
-                    {
-                        _dataStore.InputDiscretes.Add(false);
-                    }
+                    _dataStore = new SlaveDataStore();
                     
                     // Initialize some test data in holding registers
+                    // NModbus 3 uses 0-based index for API
                     for (ushort i = 1; i <= 16; i++)
-                        _dataStore.HoldingRegisters[i] = (ushort)(i * 10);
+                    {
+                        _dataStore.HoldingRegisters.WritePoints((ushort)(i - 1), new ushort[] { (ushort)(i * 10) });
+                    }
                     
                     // Create and start TCP listener
                     _listener = new TcpListener(endpoint);
                     _listener.Start();
                     
-                    // Create slave
-                    _slave = ModbusTcpSlave.CreateTcp(DefaultSlaveId, _listener);
-                    _slave.DataStore = _dataStore;
+                    // Create slave network
+                    _slaveNetwork = _factory.CreateSlaveNetwork(_listener);
+                    IModbusSlave slave = _factory.CreateSlave(DefaultSlaveId, _dataStore);
+                    _slaveNetwork.AddSlave(slave);
                     
                     // Start listening for connections
                     _cts = new CancellationTokenSource();
                     _isRunning = true; // Set before starting listen task
-                    _listenTask = Task.Run(() =>
+                    _listenTask = Task.Run(async () =>
                     {
-                        try { _slave.Listen(); }
+                        try { await _slaveNetwork.ListenAsync(_cts.Token); }
+                        catch (OperationCanceledException) { }
                         catch (Exception ex) { _logger.LogError(ex, "Listen task failed"); }
                     });
                     
@@ -172,7 +159,7 @@ namespace ModbusForge.Services
             try
             {
                 _cts?.Cancel();
-                _slave?.Dispose();
+                _slaveNetwork?.Dispose();
                 _listener?.Stop();
             }
             catch (Exception ex)
@@ -181,7 +168,7 @@ namespace ModbusForge.Services
             }
             finally
             {
-                _slave = null;
+                _slaveNetwork = null;
                 _listener = null;
                 _cts?.Dispose();
                 _cts = null;
@@ -189,7 +176,7 @@ namespace ModbusForge.Services
         }
 
         // Data store access for simulation service
-        public DataStore? GetDataStore()
+        public ISlaveDataStore? GetDataStore()
         {
             lock (_stateLock)
             {
@@ -241,15 +228,19 @@ namespace ModbusForge.Services
                 _logger.LogDebug($"Reading {count} holding registers starting at {startAddress} (Unit ID: {unitId})");
 
                 var registers = _dataStore?.HoldingRegisters;
-                if (registers == null || startAddress < 1 || count < 0 || startAddress + count - 1 > registers.Count)
+                if (registers == null)
+                    throw new InvalidOperationException("Data store not initialized");
+
+                try
+                {
+                    var result = registers.ReadPoints((ushort)(startAddress > 0 ? startAddress - 1 : 0), (ushort)count);
+                    _logger.LogDebug($"Successfully read {result.Length} registers");
+                    return result;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
                     throw new ArgumentOutOfRangeException(nameof(startAddress), "Requested range is out of bounds");
-
-                var result = new ushort[count];
-                for (int i = 0; i < count; i++)
-                    result[i] = registers[(ushort)(startAddress + i)];
-
-                _logger.LogDebug($"Successfully read {result.Length} registers");
-                return result;
+                }
             });
         }
 
@@ -265,11 +256,18 @@ namespace ModbusForge.Services
                     _logger.LogDebug($"Writing value {value} to register {registerAddress} (Unit ID: {unitId})");
 
                     var registers = _dataStore?.HoldingRegisters;
-                    if (registers == null || registerAddress < 1 || registerAddress > registers.Count)
-                        throw new ArgumentOutOfRangeException(nameof(registerAddress), "Register address is out of range");
+                    if (registers == null)
+                        throw new InvalidOperationException("Data store not initialized");
 
-                    registers[(ushort)registerAddress] = value;
-                    _logger.LogDebug("Successfully wrote to register");
+                    try
+                    {
+                        registers.WritePoints((ushort)(registerAddress > 0 ? registerAddress - 1 : 0), new ushort[] { value });
+                        _logger.LogDebug("Successfully wrote to register");
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(registerAddress), "Register address is out of range");
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -289,15 +287,19 @@ namespace ModbusForge.Services
                 _logger.LogDebug($"Reading {count} coils starting at {startAddress} (Unit ID: {unitId})");
 
                 var coils = _dataStore?.CoilDiscretes;
-                if (coils == null || startAddress < 1 || count < 0 || startAddress + count - 1 > coils.Count)
+                if (coils == null)
+                    throw new InvalidOperationException("Data store not initialized");
+
+                try
+                {
+                    var result = coils.ReadPoints((ushort)(startAddress > 0 ? startAddress - 1 : 0), (ushort)count);
+                    _logger.LogDebug($"Successfully read {result.Length} coils");
+                    return result;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
                     throw new ArgumentOutOfRangeException(nameof(startAddress), "Requested coil range is out of bounds");
-
-                var result = new bool[count];
-                for (int i = 0; i < count; i++)
-                    result[i] = coils[(ushort)(startAddress + i)];
-
-                _logger.LogDebug($"Successfully read {result.Length} coils");
-                return result;
+                }
             });
         }
 
@@ -313,11 +315,18 @@ namespace ModbusForge.Services
                     _logger.LogDebug($"Writing coil at {coilAddress} = {value} (Unit ID: {unitId})");
 
                     var coils = _dataStore?.CoilDiscretes;
-                    if (coils == null || coilAddress < 1 || coilAddress > coils.Count)
-                        throw new ArgumentOutOfRangeException(nameof(coilAddress), "Coil address is out of range");
+                    if (coils == null)
+                        throw new InvalidOperationException("Data store not initialized");
 
-                    coils[(ushort)coilAddress] = value;
-                    _logger.LogDebug("Successfully wrote coil");
+                    try
+                    {
+                        coils.WritePoints((ushort)(coilAddress > 0 ? coilAddress - 1 : 0), new bool[] { value });
+                        _logger.LogDebug("Successfully wrote coil");
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(coilAddress), "Coil address is out of range");
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -342,13 +351,13 @@ namespace ModbusForge.Services
                     try
                     {
                         _cts?.Cancel();
-                        _slave?.Dispose();
+                        _slaveNetwork?.Dispose();
                         _listener?.Stop();
                     }
                     catch { /* ignore on dispose */ }
                     finally
                     {
-                        _slave = null;
+                        _slaveNetwork = null;
                         _listener = null;
                         _cts?.Dispose();
                         _cts = null;

--- a/ModbusForge/Services/ModbusService.cs
+++ b/ModbusForge/Services/ModbusService.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-using Modbus.Device;
+using NModbus;
 using Microsoft.Extensions.Logging;
 
 namespace ModbusForge.Services
@@ -12,6 +12,7 @@ namespace ModbusForge.Services
     {
         private readonly ILogger<ModbusService> _logger;
         private IModbusMaster? _client;
+        private readonly IModbusFactory _factory = new ModbusFactory();
         private TcpClient? _tcpClient;
         private bool _disposed = false;
 
@@ -84,7 +85,7 @@ namespace ModbusForge.Services
                     _logger.LogInformation($"Connecting to Modbus server at {ipAddress}:{port}");
                     _tcpClient = new TcpClient();
                     _tcpClient.Connect(ipAddress, port);
-                    _client = ModbusIpMaster.CreateIp(_tcpClient);
+                    _client = _factory.CreateMaster(_tcpClient);
                     _logger.LogInformation($"Connected to Modbus server: {IsConnected}");
                     return true;
                 }

--- a/ModbusForge/Services/ModbusTcpService.cs
+++ b/ModbusForge/Services/ModbusTcpService.cs
@@ -1,4 +1,4 @@
-using Modbus.Device;
+using NModbus;
 using System;
 using System.Net;
 using System.Net.Sockets;
@@ -13,6 +13,7 @@ namespace ModbusForge.Services
     public class ModbusTcpService : IModbusService, IDisposable
     {
         private IModbusMaster? _client;
+        private readonly IModbusFactory _factory = new ModbusFactory();
         private TcpClient? _tcpClient;
         private bool _disposed = false;
         private readonly ILogger<ModbusTcpService> _logger;
@@ -144,7 +145,7 @@ namespace ModbusForge.Services
                         _lastPort = port;
                         _tcpClient = new TcpClient();
                         _tcpClient.Connect(ipAddress, port);
-                        _client = ModbusIpMaster.CreateIp(_tcpClient);
+                        _client = _factory.CreateMaster(_tcpClient);
                         _logger.LogInformation($"Connected to Modbus server at {ipAddress}:{port}");
                         return true;
                     }
@@ -414,7 +415,7 @@ namespace ModbusForge.Services
                 sw.Restart();
                 _logger.LogInformation($"Diagnostics: Testing Modbus protocol with Unit ID {unitId}");
                 
-                var master = ModbusIpMaster.CreateIp(testClient);
+                var master = new ModbusFactory().CreateMaster(testClient);
                 master.Transport.ReadTimeout = 5000;
                 master.Transport.WriteTimeout = 5000;
 
@@ -426,7 +427,7 @@ namespace ModbusForge.Services
                     result.ModbusResponding = true;
                     _logger.LogInformation($"Diagnostics: Modbus responded in {result.ModbusLatencyMs}ms, read value: {registers[0]}");
                 }
-                catch (Modbus.SlaveException slaveEx)
+                catch (NModbus.SlaveException slaveEx)
                 {
                     // Slave responded with an exception - this means Modbus IS working, just the request was invalid
                     result.ModbusLatencyMs = (int)sw.ElapsedMilliseconds;

--- a/ModbusForge/Services/SimulationService.cs
+++ b/ModbusForge/Services/SimulationService.cs
@@ -96,8 +96,11 @@ namespace ModbusForge.Services
                             for (int i = 0; i < count; i++)
                             {
                                 int addr = start + i;
-                                if (addr >= 0 && addr < dataStore.HoldingRegisters.Count)
-                                    dataStore.HoldingRegisters[addr] = (ushort)iv;
+                                if (addr >= 1)
+                                {
+                                    try { dataStore.HoldingRegisters.WritePoints((ushort)(addr - 1), new ushort[] { (ushort)iv }); }
+                                    catch (ArgumentOutOfRangeException) { }
+                                }
                             }
                         }
                     }
@@ -114,8 +117,11 @@ namespace ModbusForge.Services
                                 if (val < 0) val = 0;
                                 if (val > 65535) val = 65535;
                                 int addr = start + i;
-                                if (addr >= 0 && addr < dataStore.HoldingRegisters.Count)
-                                    dataStore.HoldingRegisters[addr] = (ushort)val;
+                                if (addr >= 1)
+                                {
+                                    try { dataStore.HoldingRegisters.WritePoints((ushort)(addr - 1), new ushort[] { (ushort)val }); }
+                                    catch (ArgumentOutOfRangeException) { }
+                                }
                             }
                         }
                     }
@@ -131,8 +137,11 @@ namespace ModbusForge.Services
                         for (int i = 0; i < count; i++)
                         {
                             int addr = start + i;
-                            if (addr >= 0 && addr < dataStore.CoilDiscretes.Count)
-                                dataStore.CoilDiscretes[addr] = _simCoilState;
+                            if (addr >= 1)
+                            {
+                                try { dataStore.CoilDiscretes.WritePoints((ushort)(addr - 1), new bool[] { _simCoilState }); }
+                                catch (ArgumentOutOfRangeException) { }
+                            }
                         }
                         _simCoilState = !_simCoilState;
                     }
@@ -155,8 +164,11 @@ namespace ModbusForge.Services
                             if (val < 0) val = 0;
                             if (val > 65535) val = 65535;
                             int addr = start + i;
-                            if (addr >= 0 && addr < dataStore.InputRegisters.Count)
-                                dataStore.InputRegisters[addr] = (ushort)val;
+                            if (addr >= 1)
+                            {
+                                try { dataStore.InputRegisters.WritePoints((ushort)(addr - 1), new ushort[] { (ushort)val }); }
+                                catch (ArgumentOutOfRangeException) { }
+                            }
                         }
                     }
                 }
@@ -171,8 +183,11 @@ namespace ModbusForge.Services
                         for (int i = 0; i < count; i++)
                         {
                             int addr = start + i;
-                            if (addr >= 0 && addr < dataStore.InputDiscretes.Count)
-                                dataStore.InputDiscretes[addr] = _simDiscreteState;
+                            if (addr >= 1)
+                            {
+                                try { dataStore.CoilInputs.WritePoints((ushort)(addr - 1), new bool[] { _simDiscreteState }); }
+                                catch (ArgumentOutOfRangeException) { }
+                            }
                         }
                         _simDiscreteState = !_simDiscreteState;
                     }


### PR DESCRIPTION
🎯 **What:** The unmaintained and deprecated `NModbus4` package has been replaced with the actively maintained `NModbus` library (v3.0.81). This involved significant refactoring to adopt the new NModbus v3 API structure.
⚠️ **Risk:** Sticking with an unmaintained dependency (`NModbus4`) introduces security risks if zero-day vulnerabilities are found in the legacy library. It also limits support for newer features and bug fixes.
🛡️ **Solution:** The `ModbusForge.csproj` was updated to reference the latest stable `NModbus` package. The codebase was refactored as follows:
- Adopted the `IModbusFactory` pattern for creating Modbus Master and Slave networks (`ModbusTcpService`, `ModbusService`, `ModbusServerService`).
- Replaced `ModbusTcpSlave` with `IModbusSlaveNetwork`, enabling modern `ListenAsync()` loops with proper `CancellationToken` support, enhancing server lifecycle management (clean stopping).
- Updated internal data store access (`DataStore` -> `ISlaveDataStore`), utilizing the `ReadPoints` and `WritePoints` methods with bounds checking properly integrated into the legacy 1-based API behaviors.
- The `SimulationService` was similarly updated to safely use these new data store methods.

---
*PR created automatically by Jules for task [16888009927799121979](https://jules.google.com/task/16888009927799121979) started by @nokkies*