### PR TITLE
🧹 Fix empty catch block in ModbusMultiUnitServer

### DIFF
--- a/ModbusForge/Services/ModbusMultiUnitServer.cs
+++ b/ModbusForge/Services/ModbusMultiUnitServer.cs
@@ -155,14 +155,18 @@ namespace ModbusForge.Services
             }
         }
 
-        private static async Task<bool> ReadExactAsync(NetworkStream stream, byte[] buffer, int count, CancellationToken ct)
+        private async Task<bool> ReadExactAsync(NetworkStream stream, byte[] buffer, int count, CancellationToken ct)
         {
             int offset = 0;
             while (offset < count)
             {
                 int read;
                 try { read = await stream.ReadAsync(buffer.AsMemory(offset, count - offset), ct); }
-                catch { return false; }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Error reading from stream");
+                    return false;
+                }
                 if (read == 0) return false;
                 offset += read;
             }


### PR DESCRIPTION
- 🎯 **What:** Replaced an empty catch block in `ReadExactAsync` with a try-catch that logs exceptions at the Debug level.
- 💡 **Why:** Improves maintainability and observability of connection issues. By converting `ReadExactAsync` to an instance method, we can now utilize the class's logger to record why a read operation failed while still preserving the original behavior of returning `false` to signal failure to the caller.
- ✅ **Verification:** Manually inspected the code to ensure that exceptions are caught and logged, and that the return value remains consistent with the previous implementation for both success and failure cases.
- ✨ **Result:** Better error tracking for Modbus TCP server client connections without changing the application's overall behavior.

---
*PR created automatically by Jules for task [13403978297569008675](https://jules.google.com/task/13403978297569008675) started by @nokkies*