### PR TITLE
🧪 Add unit tests for Script cloning

### DIFF
--- a/ModbusForge.Tests/Models/ScriptTests.cs
+++ b/ModbusForge.Tests/Models/ScriptTests.cs
@@ -1,0 +1,112 @@
+using ModbusForge.Models;
+using Xunit;
+
+namespace ModbusForge.Tests.Models;
+
+public class ScriptTests
+{
+    [Fact]
+    public void Clone_ShouldCopyPrimitiveProperties()
+    {
+        // Arrange
+        var original = new Script("Test Script")
+        {
+            Description = "Test Description",
+            StopOnError = false,
+            RepeatCount = 5,
+            DelayBetweenCommandsMs = 500
+        };
+
+        // Act
+        var clone = original.Clone();
+
+        // Assert
+        Assert.Equal(original.Description, clone.Description);
+        Assert.Equal(original.StopOnError, clone.StopOnError);
+        Assert.Equal(original.RepeatCount, clone.RepeatCount);
+        Assert.Equal(original.DelayBetweenCommandsMs, clone.DelayBetweenCommandsMs);
+    }
+
+    [Fact]
+    public void Clone_ShouldAppendCopySuffixToName()
+    {
+        // Arrange
+        var original = new Script("Test Script");
+
+        // Act
+        var clone = original.Clone();
+
+        // Assert
+        Assert.Equal("Test Script (Copy)", clone.Name);
+    }
+
+    [Fact]
+    public void Clone_ShouldGenerateNewId()
+    {
+        // Arrange
+        var original = new Script("Test Script");
+
+        // Act
+        var clone = original.Clone();
+
+        // Assert
+        Assert.NotEqual(original.Id, clone.Id);
+        Assert.False(string.IsNullOrEmpty(clone.Id));
+    }
+
+    [Fact]
+    public void Clone_ShouldPerformDeepCopyOfCommands()
+    {
+        // Arrange
+        var original = new Script("Test Script");
+        var command = new ScriptCommand
+        {
+            CommandType = ScriptCommandType.ReadHoldingRegisters,
+            Address = 100,
+            Count = 10
+        };
+        original.Commands.Add(command);
+
+        // Act
+        var clone = original.Clone();
+
+        // Assert
+        Assert.Single(clone.Commands);
+        Assert.NotSame(original.Commands[0], clone.Commands[0]);
+        Assert.Equal(original.Commands[0].CommandType, clone.Commands[0].CommandType);
+        Assert.Equal(original.Commands[0].Address, clone.Commands[0].Address);
+        Assert.Equal(original.Commands[0].Count, clone.Commands[0].Count);
+    }
+
+    [Fact]
+    public void Clone_ModifyingClone_ShouldNotAffectOriginal()
+    {
+        // Arrange
+        var original = new Script("Original");
+        original.Commands.Add(new ScriptCommand { Address = 1 });
+        var clone = original.Clone();
+
+        // Act
+        clone.Name = "Modified Clone";
+        clone.Commands[0].Address = 2;
+        clone.Commands.Add(new ScriptCommand { Address = 3 });
+
+        // Assert
+        Assert.Equal("Original", original.Name);
+        Assert.Equal(1, original.Commands[0].Address);
+        Assert.Single(original.Commands);
+    }
+
+    [Fact]
+    public void Clone_ShouldCreateNewCommandsListInstance()
+    {
+        // Arrange
+        var original = new Script("Original");
+
+        // Act
+        var clone = original.Clone();
+
+        // Assert
+        Assert.NotSame(original.Commands, clone.Commands);
+    }
+}

--- a/ModbusForge/Models/Script.cs
+++ b/ModbusForge/Models/Script.cs
@@ -7,6 +7,9 @@ namespace ModbusForge.Models;
 public partial class Script : ObservableObject
 {
     [ObservableProperty]
+    private string _id = Guid.NewGuid().ToString();
+
+    [ObservableProperty]
     private string _name = "New Script";
 
     [ObservableProperty]


### PR DESCRIPTION
This PR introduces comprehensive unit tests for the `Script.Clone()` method and improves the `Script` model's identity management.

### 🎯 What: The testing gap addressed
Previously, the `Script.Clone()` method lacked dedicated unit tests, making it difficult to verify if deep cloning of properties and child collections was working correctly.

### 📊 Coverage: What scenarios are now tested
- **Primitive Properties:** Verified that `Description`, `StopOnError`, `RepeatCount`, and `DelayBetweenCommandsMs` are copied correctly.
- **Name Suffix:** Ensured the cloned script's name is appended with " (Copy)".
- **Unique Identity:** Confirmed that each clone receives a new, unique `Id`.
- **Deep Copy of Commands:** Verified that the `Commands` collection is deep-copied (new collection instance and new command instances).
- **Isolation:** Confirmed that modifying the clone does not affect the original script.

### ✨ Result: The improvement in test coverage
By adding these tests and refining the `Script` model, we ensure that script duplication—a core feature for user productivity—is reliable and free of side effects like shared state between scripts.

---
*PR created automatically by Jules for task [16682610947828134697](https://jules.google.com/task/16682610947828134697) started by @nokkies*