### PR TITLE
Fix InputInt and InputBool node address migration

### DIFF
--- a/ModbusForge/ViewModels/MainViewModel.cs
+++ b/ModbusForge/ViewModels/MainViewModel.cs
@@ -1681,24 +1681,30 @@ namespace ModbusForge.ViewModels
 
         private void MigrateOldNodeAddresses(VisualNode node)
         {
-            // Fix InputInt nodes with missing OutputAddress
-            if (node.ElementType == PlcElementType.InputInt && node.OutputAddress == null)
+            // Fix InputInt nodes with missing or default OutputAddress (Coil:0)
+            if (node.ElementType == PlcElementType.InputInt)
             {
-                node.OutputAddress = new PlcAddressReference 
-                { 
-                    Area = PlcArea.HoldingRegister, 
-                    Address = node.Input1Address?.Address ?? 1 
-                };
+                if (node.OutputAddress == null || (node.OutputAddress.Area == PlcArea.Coil && node.OutputAddress.Address == 0))
+                {
+                    node.OutputAddress = new PlcAddressReference
+                    {
+                        Area = PlcArea.HoldingRegister,
+                        Address = (node.Input1Address != null && node.Input1Address.Address > 0) ? node.Input1Address.Address : 1
+                    };
+                }
             }
             
-            // Fix InputBool nodes with missing OutputAddress
-            if (node.ElementType == PlcElementType.InputBool && node.OutputAddress == null)
+            // Fix InputBool nodes with missing or default OutputAddress (Coil:0)
+            if (node.ElementType == PlcElementType.InputBool)
             {
-                node.OutputAddress = new PlcAddressReference 
-                { 
-                    Area = PlcArea.Coil, 
-                    Address = node.Input1Address?.Address ?? 1 
-                };
+                if (node.OutputAddress == null || (node.OutputAddress.Area == PlcArea.Coil && node.OutputAddress.Address == 0))
+                {
+                    node.OutputAddress = new PlcAddressReference
+                    {
+                        Area = PlcArea.Coil,
+                        Address = (node.Input1Address != null && node.Input1Address.Address > 0) ? node.Input1Address.Address : 1
+                    };
+                }
             }
             
             // Fix any nodes with Coil:0 addresses (invalid)


### PR DESCRIPTION
This change fixes a bug where `InputInt` and `InputBool` nodes would not be correctly migrated if their `OutputAddress` was in the default `Coil:0` state. The migration logic now explicitly checks for this default state and ensures the appropriate Modbus area (Holding Register or Coil) is assigned, with the address mirrored from the input or defaulted to 1.

---
*PR created automatically by Jules for task [10177048795552386677](https://jules.google.com/task/10177048795552386677) started by @nokkies*