### PR TITLE
Migrate InputBool/InputInt Node OutputAddresses

### DIFF
--- a/ModbusForge/ViewModels/MainViewModel.cs
+++ b/ModbusForge/ViewModels/MainViewModel.cs
@@ -1291,6 +1291,9 @@ namespace ModbusForge.ViewModels
                     _visualNodeEditorViewModel.Nodes,
                     _visualNodeEditorViewModel.Connections,
                     SubscribeCustomEntries);
+
+                // Fix old nodes with invalid addresses (migration)
+                _visualNodeEditorViewModel.MigrateNodes();
             }
         }
 
@@ -1468,10 +1471,10 @@ namespace ModbusForge.ViewModels
                         {
                             foreach (var node in projectConfig.VisualNodes)
                             {
-                                // Fix old nodes with invalid addresses (migration)
-                                MigrateOldNodeAddresses(node);
                                 _visualNodeEditorViewModel.Nodes.Add(node);
                             }
+                            // Fix old nodes with invalid addresses (migration)
+                            _visualNodeEditorViewModel.MigrateNodes();
                         }
                         
                         if (projectConfig.VisualConnections != null)
@@ -1676,45 +1679,6 @@ namespace ModbusForge.ViewModels
             {
                 _logger.LogError(ex, "Error exporting Unit ID");
                 StatusMessage = $"Error exporting Unit ID: {ex.Message}";
-            }
-        }
-
-        private void MigrateOldNodeAddresses(VisualNode node)
-        {
-            // Fix InputInt nodes with missing OutputAddress
-            if (node.ElementType == PlcElementType.InputInt && node.OutputAddress == null)
-            {
-                node.OutputAddress = new PlcAddressReference 
-                { 
-                    Area = PlcArea.HoldingRegister, 
-                    Address = node.Input1Address?.Address ?? 1 
-                };
-            }
-            
-            // Fix InputBool nodes with missing OutputAddress
-            if (node.ElementType == PlcElementType.InputBool && node.OutputAddress == null)
-            {
-                node.OutputAddress = new PlcAddressReference 
-                { 
-                    Area = PlcArea.Coil, 
-                    Address = node.Input1Address?.Address ?? 1 
-                };
-            }
-            
-            // Fix any nodes with Coil:0 addresses (invalid)
-            if (node.OutputAddress?.Area == PlcArea.Coil && node.OutputAddress.Address == 0)
-            {
-                node.OutputAddress.Address = 1;
-            }
-            
-            if (node.Input1Address?.Area == PlcArea.Coil && node.Input1Address.Address == 0)
-            {
-                node.Input1Address.Address = 1;
-            }
-            
-            if (node.Input2Address?.Area == PlcArea.Coil && node.Input2Address.Address == 0)
-            {
-                node.Input2Address.Address = 1;
             }
         }
 

--- a/ModbusForge/ViewModels/VisualNodeEditorViewModel.cs
+++ b/ModbusForge/ViewModels/VisualNodeEditorViewModel.cs
@@ -300,6 +300,57 @@ namespace ModbusForge.ViewModels
             }
             SelectedNode = null;
         }
+
+        /// <summary>
+        /// Migrates old node configurations to the latest format, fixing missing or invalid addresses.
+        /// </summary>
+        public void MigrateNodes()
+        {
+            foreach (var node in Nodes)
+            {
+                // Fix InputInt nodes with missing or default OutputAddress (should match Input1)
+                if (node.ElementType == PlcElementType.InputInt)
+                {
+                    if (node.OutputAddress == null || (node.OutputAddress.Area == PlcArea.Coil && node.OutputAddress.Address == 0))
+                    {
+                        node.OutputAddress = new PlcAddressReference
+                        {
+                            Area = PlcArea.HoldingRegister,
+                            Address = (node.Input1Address != null && node.Input1Address.Address >= 0) ? node.Input1Address.Address : 1
+                        };
+                    }
+                }
+
+                // Fix InputBool nodes with missing or default OutputAddress (should match Input1)
+                if (node.ElementType == PlcElementType.InputBool)
+                {
+                    if (node.OutputAddress == null || (node.OutputAddress.Area == PlcArea.Coil && node.OutputAddress.Address == 0))
+                    {
+                        node.OutputAddress = new PlcAddressReference
+                        {
+                            Area = PlcArea.Coil,
+                            Address = (node.Input1Address != null && node.Input1Address.Address >= 0) ? node.Input1Address.Address : 1
+                        };
+                    }
+                }
+
+                // Fix any nodes with Coil:0 addresses (invalid - should be at least 1)
+                if (node.OutputAddress != null && node.OutputAddress.Area == PlcArea.Coil && node.OutputAddress.Address == 0)
+                {
+                    node.OutputAddress.Address = 1;
+                }
+
+                if (node.Input1Address != null && node.Input1Address.Area == PlcArea.Coil && node.Input1Address.Address == 0)
+                {
+                    node.Input1Address.Address = 1;
+                }
+
+                if (node.Input2Address != null && node.Input2Address.Area == PlcArea.Coil && node.Input2Address.Address == 0)
+                {
+                    node.Input2Address.Address = 1;
+                }
+            }
+        }
         
         public void CreateConnection(string sourceNodeId, string targetNodeId, string targetConnector = "Input1")
         {


### PR DESCRIPTION
This change addresses a data migration issue where `InputBool` and `InputInt` nodes loaded from older project files (or files missing the `OutputAddress` property) would have invalid default addresses. 

Since `VisualNode` default-initializes its address properties, a simple null check was insufficient. The migration logic now correctly detects the default-initialized `Coil:0` state and synchronizes it with the node's input address. 

Additionally, the migration logic has been centralized in `VisualNodeEditorViewModel` and integrated into all project/config loading paths in `MainViewModel`, following the project's refactoring goal of simplifying `MainViewModel`.

---
*PR created automatically by Jules for task [4649932839633365690](https://jules.google.com/task/4649932839633365690) started by @nokkies*