### PR TITLE
🔒 [security] Fix potential Command Injection / Open Redirect via Process.Start

### DIFF
--- a/ModbusForge.Tests/Helpers/UrlHelperTests.cs
+++ b/ModbusForge.Tests/Helpers/UrlHelperTests.cs
@@ -1,0 +1,41 @@
+using ModbusForge.Helpers;
+using Xunit;
+
+namespace ModbusForge.Tests.Helpers
+{
+    public class UrlHelperTests
+    {
+        [Theory]
+        [InlineData("http://example.com")]
+        [InlineData("https://example.com")]
+        [InlineData("https://www.paypal.com/donate/?hosted_button_id=ELTVNJEYLZE3W")]
+        [InlineData("mailto:test@example.com")]
+        public void IsValidUrl_ShouldReturnTrue_ForAllowedSchemes(string url)
+        {
+            // Act
+            bool result = UrlHelper.IsValidUrl(url);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not-a-url")]
+        [InlineData("C:\\Windows\\System32\\calc.exe")]
+        [InlineData("file:///etc/passwd")]
+        [InlineData("ftp://example.com")]
+        [InlineData("javascript:alert(1)")]
+        [InlineData("data:text/plain,hello")]
+        public void IsValidUrl_ShouldReturnFalse_ForDisallowedOrInvalidUrls(string? url)
+        {
+            // Act
+            bool result = UrlHelper.IsValidUrl(url);
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}

--- a/ModbusForge/AboutWindow.xaml.cs
+++ b/ModbusForge/AboutWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Navigation;
 using System.Reflection;
+using ModbusForge.Helpers;
 
 namespace ModbusForge
 {
@@ -41,7 +42,7 @@ namespace ModbusForge
         {
             try
             {
-                Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+                UrlHelper.OpenUrl(e.Uri.AbsoluteUri);
             }
             catch (Exception ex)
             {

--- a/ModbusForge/Helpers/UrlHelper.cs
+++ b/ModbusForge/Helpers/UrlHelper.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Diagnostics;
+
+namespace ModbusForge.Helpers
+{
+    /// <summary>
+    /// Helper class for safely opening URLs and preventing command injection or open redirects.
+    /// </summary>
+    public static class UrlHelper
+    {
+        /// <summary>
+        /// Validates and opens the specified URL using the system's default handler.
+        /// </summary>
+        /// <param name="url">The URL to open.</param>
+        public static void OpenUrl(string? url)
+        {
+            if (IsValidUrl(url))
+            {
+                Process.Start(new ProcessStartInfo(url!) { UseShellExecute = true });
+            }
+        }
+
+        /// <summary>
+        /// Validates if a URL is an absolute URI and uses an allowed scheme (http, https, or mailto).
+        /// </summary>
+        /// <param name="url">The URL to validate.</param>
+        /// <returns>True if the URL is valid and safe to open; otherwise, false.</returns>
+        public static bool IsValidUrl(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return false;
+
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                return false;
+
+            return uri.Scheme == Uri.UriSchemeHttp ||
+                   uri.Scheme == Uri.UriSchemeHttps ||
+                   uri.Scheme == "mailto";
+        }
+    }
+}

--- a/ModbusForge/MainWindow.xaml.cs
+++ b/ModbusForge/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Diagnostics;
 using ModbusForge.Models;
 using ModbusForge.Services;
+using ModbusForge.Helpers;
 using MahApps.Metro.Controls;
 using System.Collections.ObjectModel;
 
@@ -57,7 +58,7 @@ namespace ModbusForge
             try
             {
                 var url = "https://www.paypal.com/donate/?hosted_button_id=ELTVNJEYLZE3W";
-                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+                UrlHelper.OpenUrl(url);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This PR fixes a potential command injection and open redirect vulnerability where user-controlled URIs were passed directly to `Process.Start` with `UseShellExecute = true`. 

By introducing `UrlHelper.OpenUrl`, we now ensure that only absolute URIs with safe schemes (`http`, `https`, or `mailto`) are processed. This prevents attackers from executing arbitrary commands or opening local files by providing malicious URI strings.

Key changes:
- Created `ModbusForge/Helpers/UrlHelper.cs` with validation logic.
- Refactored `AboutWindow.xaml.cs` and `MainWindow.xaml.cs` to use `UrlHelper`.
- Added `ModbusForge.Tests/Helpers/UrlHelperTests.cs` to verify the security fix.

---
*PR created automatically by Jules for task [4174498024186048678](https://jules.google.com/task/4174498024186048678) started by @nokkies*