### PR TITLE
🧪 Decouple ConsoleLoggerService and add unit tests

### DIFF
--- a/ModbusForge.Tests/Services/ConsoleLoggerServiceTests.cs
+++ b/ModbusForge.Tests/Services/ConsoleLoggerServiceTests.cs
@@ -1,0 +1,58 @@
+using System;
+using ModbusForge.Services;
+using Xunit;
+
+namespace ModbusForge.Tests.Services
+{
+    public class ConsoleLoggerServiceTests
+    {
+        [Fact]
+        public void Log_RaisesLogMessageReceivedEvent()
+        {
+            // Arrange
+            var service = new ConsoleLoggerService();
+            string receivedMessage = string.Empty;
+            string testMessage = "Test Log Message";
+
+            service.LogMessageReceived += (sender, e) =>
+            {
+                receivedMessage = e.Message;
+            };
+
+            // Act
+            service.Log(testMessage);
+
+            // Assert
+            Assert.Equal(testMessage, receivedMessage);
+        }
+
+        [Fact]
+        public void Log_WorksWithMultipleSubscribers()
+        {
+            // Arrange
+            var service = new ConsoleLoggerService();
+            int callCount = 0;
+            string testMessage = "Broadcast Message";
+
+            service.LogMessageReceived += (sender, e) => callCount++;
+            service.LogMessageReceived += (sender, e) => callCount++;
+
+            // Act
+            service.Log(testMessage);
+
+            // Assert
+            Assert.Equal(2, callCount);
+        }
+
+        [Fact]
+        public void Log_DoesNotThrow_WhenNoSubscribers()
+        {
+            // Arrange
+            var service = new ConsoleLoggerService();
+
+            // Act & Assert
+            var exception = Record.Exception(() => service.Log("No one is listening"));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/ModbusForge/Services/ConsoleLoggerService.cs
+++ b/ModbusForge/Services/ConsoleLoggerService.cs
@@ -1,18 +1,14 @@
-using System.Collections.ObjectModel;
-using System.Windows;
+using System;
 
 namespace ModbusForge.Services
 {
     public class ConsoleLoggerService : IConsoleLoggerService
     {
-        public ObservableCollection<string> LogMessages { get; } = new ObservableCollection<string>();
+        public event EventHandler<LogMessageEventArgs>? LogMessageReceived;
 
         public void Log(string message)
         {
-            Application.Current.Dispatcher.Invoke(() =>
-            {
-                LogMessages.Add(message);
-            });
+            LogMessageReceived?.Invoke(this, new LogMessageEventArgs(message));
         }
     }
 }

--- a/ModbusForge/Services/IConsoleLoggerService.cs
+++ b/ModbusForge/Services/IConsoleLoggerService.cs
@@ -1,10 +1,10 @@
-using System.Collections.ObjectModel;
+using System;
 
 namespace ModbusForge.Services
 {
     public interface IConsoleLoggerService
     {
-        ObservableCollection<string> LogMessages { get; }
+        event EventHandler<LogMessageEventArgs>? LogMessageReceived;
         void Log(string message);
     }
 }

--- a/ModbusForge/Services/LogMessageEventArgs.cs
+++ b/ModbusForge/Services/LogMessageEventArgs.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace ModbusForge.Services
+{
+    public class LogMessageEventArgs : EventArgs
+    {
+        public string Message { get; }
+        public LogMessageEventArgs(string message)
+        {
+            Message = message;
+        }
+    }
+}

--- a/ModbusForge/ViewModels/MainViewModel.cs
+++ b/ModbusForge/ViewModels/MainViewModel.cs
@@ -266,6 +266,9 @@ namespace ModbusForge.ViewModels
         /// </summary>
         private void InitializeTimersAndServices()
         {
+            // Subscribe to console log events
+            _consoleLoggerService.LogMessageReceived += ConsoleLoggerService_LogMessageReceived;
+
             // Custom writer timer
             _customTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
             _customTimer.Tick += CustomTimer_Tick;
@@ -284,6 +287,20 @@ namespace ModbusForge.ViewModels
             // Start services
             try { _trendLogger.Start(); } catch (Exception ex) { _logger.LogWarning(ex, "Failed to start trend logger"); }
             SubscribeCustomEntries();
+        }
+
+        private void ConsoleLoggerService_LogMessageReceived(object? sender, LogMessageEventArgs e)
+        {
+            Application.Current?.Dispatcher?.Invoke(() =>
+            {
+                ConsoleMessages.Add(e.Message);
+
+                // Keep the last 1000 messages by default
+                while (ConsoleMessages.Count > 1000)
+                {
+                    ConsoleMessages.RemoveAt(0);
+                }
+            });
         }
 
         [ObservableProperty]
@@ -404,7 +421,7 @@ namespace ModbusForge.ViewModels
         public IRelayCommand SaveAllConfigCommand { get; private set; }
         public IRelayCommand LoadAllConfigCommand { get; private set; }
 
-        public ObservableCollection<string> ConsoleMessages => _consoleLoggerService.LogMessages;
+        public ObservableCollection<string> ConsoleMessages { get; } = new();
 
         // Register collections (shared across all Unit IDs for display)
         public ObservableCollection<RegisterEntry> HoldingRegisters { get; } = new();
@@ -749,6 +766,7 @@ namespace ModbusForge.ViewModels
                 {
                     try
                     {
+                        _consoleLoggerService.LogMessageReceived -= ConsoleLoggerService_LogMessageReceived;
                         _customTimer.Stop();
                         _customTimer.Tick -= CustomTimer_Tick;
                         _monitorTimer.Stop();


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: `ConsoleLoggerService` was tightly coupled to WPF's `Dispatcher`, making it impossible to unit test.
📊 **Coverage:** Added tests for `Log` method (event raising, multiple subscribers, no subscribers).
✨ **Result:** Refactored to an event-based model, decoupled from the UI, and added unit tests in `ModbusForge.Tests/Services/ConsoleLoggerServiceTests.cs`.

---
*PR created automatically by Jules for task [6470520867938728765](https://jules.google.com/task/6470520867938728765) started by @nokkies*