### PR TITLE
🧹 Fix empty catch blocks in ModbusServerService

### DIFF
--- a/ModbusForge/Services/ModbusServerService.cs
+++ b/ModbusForge/Services/ModbusServerService.cs
@@ -84,7 +84,15 @@ namespace ModbusForge.Services
 
         private void CleanupResources()
         {
-            try { _multiServer?.Stop(); } catch { }
+            try
+            {
+                _multiServer?.Stop();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error while stopping Modbus multi-unit server");
+            }
+
             _multiServer?.Dispose();
             _multiServer = null;
         }
@@ -107,7 +115,7 @@ namespace ModbusForge.Services
             }
         }
 
-        private static string GetLocalNetworkIp()
+        private string GetLocalNetworkIp()
         {
             try
             {
@@ -119,7 +127,10 @@ namespace ModbusForge.Services
                 if (ips.Count > 0)
                     return string.Join(", ", ips);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to resolve local network IP addresses");
+            }
             return "0.0.0.0";
         }
 
@@ -242,7 +253,14 @@ namespace ModbusForge.Services
             {
                 if (disposing)
                 {
-                    try { CleanupResources(); } catch { }
+                    try
+                    {
+                        CleanupResources();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Error during CleanupResources in Dispose");
+                    }
                     _isRunning = false;
                 }
                 _disposed = true;


### PR DESCRIPTION
This change improves the maintainability and observability of ModbusServerService by replacing empty catch blocks with proper logging using ILogger. Specifically, exceptions during local IP resolution, server stopping, and resource cleanup are now logged as warnings. GetLocalNetworkIp was converted to an instance method to facilitate this logging.

---
*PR created automatically by Jules for task [15470251967359907546](https://jules.google.com/task/15470251967359907546) started by @nokkies*