### PR TITLE
🧪 Add unit tests for BitConverterHelper

### DIFF
--- a/ModbusForge.Tests/Helpers/BitConverterHelperTests.cs
+++ b/ModbusForge.Tests/Helpers/BitConverterHelperTests.cs
@@ -1,0 +1,112 @@
+using System;
+using ModbusForge.Helpers;
+using Xunit;
+
+namespace ModbusForge.Tests.Helpers
+{
+    public class BitConverterHelperTests
+    {
+        [Fact]
+        public void ToBooleanArray_SingleByte_ReturnsCorrectBits()
+        {
+            // Arrange
+            byte[] bytes = { 0b10101010 }; // 0xAA, decimal 170
+            // Bits (LSB first): 0, 1, 0, 1, 0, 1, 0, 1
+            int count = 8;
+
+            // Act
+            bool[] result = BitConverterHelper.ToBooleanArray(bytes, count);
+
+            // Assert
+            Assert.Equal(count, result.Length);
+            Assert.False(result[0]);
+            Assert.True(result[1]);
+            Assert.False(result[2]);
+            Assert.True(result[3]);
+            Assert.False(result[4]);
+            Assert.True(result[5]);
+            Assert.False(result[6]);
+            Assert.True(result[7]);
+        }
+
+        [Fact]
+        public void ToBooleanArray_MultipleBytes_ReturnsCorrectBits()
+        {
+            // Arrange
+            byte[] bytes = { 0x01, 0x80 };
+            // 0x01: 1, 0, 0, 0, 0, 0, 0, 0
+            // 0x80: 0, 0, 0, 0, 0, 0, 0, 1
+            int count = 16;
+
+            // Act
+            bool[] result = BitConverterHelper.ToBooleanArray(bytes, count);
+
+            // Assert
+            Assert.Equal(count, result.Length);
+            Assert.True(result[0]);
+            Assert.False(result[1]);
+            Assert.False(result[14]);
+            Assert.True(result[15]);
+        }
+
+        [Fact]
+        public void ToBooleanArray_Truncation_ReturnsOnlyRequestedCount()
+        {
+            // Arrange
+            byte[] bytes = { 0xFF }; // All true
+            int count = 3;
+
+            // Act
+            bool[] result = BitConverterHelper.ToBooleanArray(bytes, count);
+
+            // Assert
+            Assert.Equal(count, result.Length);
+            Assert.All(result, Assert.True);
+        }
+
+        [Fact]
+        public void ToBooleanArray_Padding_FillsWithFalse()
+        {
+            // Arrange
+            byte[] bytes = { 0xFF };
+            int count = 10;
+
+            // Act
+            bool[] result = BitConverterHelper.ToBooleanArray(bytes, count);
+
+            // Assert
+            Assert.Equal(count, result.Length);
+            for (int i = 0; i < 8; i++) Assert.True(result[i]);
+            for (int i = 8; i < 10; i++) Assert.False(result[i]);
+        }
+
+        [Fact]
+        public void ToBooleanArray_EmptyInput_ReturnsFalseArray()
+        {
+            // Arrange
+            byte[] bytes = Array.Empty<byte>();
+            int count = 5;
+
+            // Act
+            bool[] result = BitConverterHelper.ToBooleanArray(bytes, count);
+
+            // Assert
+            Assert.Equal(count, result.Length);
+            Assert.All(result, Assert.False);
+        }
+
+        [Fact]
+        public void ToBooleanArray_ZeroCount_ReturnsEmptyArray()
+        {
+            // Arrange
+            byte[] bytes = { 0xFF };
+            int count = 0;
+
+            // Act
+            bool[] result = BitConverterHelper.ToBooleanArray(bytes, count);
+
+            // Assert
+            Assert.Empty(result);
+        }
+    }
+}


### PR DESCRIPTION
I have implemented comprehensive unit tests for `BitConverterHelper.ToBooleanArray`. The tests cover standard conversion, bit ordering (LSB first), multi-byte indexing, truncation, padding, and edge cases like empty inputs.

Verification was challenging due to the Linux environment's lack of NuGet access and WPF dependencies in the main test project. I overcame this by:
1. Writing a standalone `VerificationApp.cs` that mirrors the tests.
2. Compiling it manually using the Roslyn compiler DLL (`csc.dll`) and referencing core assemblies (`System.Runtime.dll`, etc.) from the .NET packs.
3. Successfully running the tests and verifying they fail when the logic is intentionally broken.

The tests ensure the core bit-conversion logic is reliable and handles boundary conditions correctly.

---
*PR created automatically by Jules for task [3594301657491089015](https://jules.google.com/task/3594301657491089015) started by @nokkies*