### PR TITLE
🧹 [Code Health] Remove empty catch blocks in ModbusServerService

### DIFF
--- a/ModbusForge/Services/ModbusServerService.cs
+++ b/ModbusForge/Services/ModbusServerService.cs
@@ -84,7 +84,8 @@ namespace ModbusForge.Services
 
         private void CleanupResources()
         {
-            try { _multiServer?.Stop(); } catch { }
+            try { _multiServer?.Stop(); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Error stopping multi-unit server during cleanup."); }
             _multiServer?.Dispose();
             _multiServer = null;
         }
@@ -107,7 +108,7 @@ namespace ModbusForge.Services
             }
         }
 
-        private static string GetLocalNetworkIp()
+        private string GetLocalNetworkIp()
         {
             try
             {
@@ -119,7 +120,10 @@ namespace ModbusForge.Services
                 if (ips.Count > 0)
                     return string.Join(", ", ips);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error getting local network IP address.");
+            }
             return "0.0.0.0";
         }
 
@@ -242,7 +246,8 @@ namespace ModbusForge.Services
             {
                 if (disposing)
                 {
-                    try { CleanupResources(); } catch { }
+                    try { CleanupResources(); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Error cleaning up resources during dispose."); }
                     _isRunning = false;
                 }
                 _disposed = true;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced three empty `catch { }` blocks in `ModbusServerService.cs` with explicit exception catching and logging via `_logger.LogWarning`. The `GetLocalNetworkIp` method was refactored from `static` to an instance method to allow access to the injected `_logger`.

💡 **Why:** How this improves maintainability
Empty catch blocks suppress exceptions, making debugging difficult when issues occur during teardown or IP resolution. Logging the exceptions makes these failures observable without changing the control flow (they are still safely handled).

✅ **Verification:** How you confirmed the change is safe
Project compiles successfully (`dotnet build -p:EnableWindowsTargeting=true`). Review of the code confirms that the refactored `GetLocalNetworkIp` is only used inside the instance scope of `BoundEndpoint`, making the conversion from `static` perfectly safe. The exception handling maintains the original safety mechanism while simply emitting logs.

✨ **Result:** The improvement achieved
Improved code health and observability by eliminating silent exception failures in the `ModbusServerService`.

---
*PR created automatically by Jules for task [12015771345499355740](https://jules.google.com/task/12015771345499355740) started by @nokkies*