### PR TITLE
🧹 Remove empty catch blocks in DecodeViewModel

### DIFF
--- a/ModbusForge/ViewModels/DecodeViewModel.cs
+++ b/ModbusForge/ViewModels/DecodeViewModel.cs
@@ -31,13 +31,13 @@ namespace ModbusForge.ViewModels
 
             _readNowCommand = new AsyncRelayCommand(ReadAsync, CanRead);
             // Ensure initial enable/disable state reflects current connection
-            try { _readNowCommand.NotifyCanExecuteChanged(); } catch { }
+            try { _readNowCommand.NotifyCanExecuteChanged(); } catch (Exception ex) { _logger.LogWarning(ex, "Failed to notify CanExecuteChanged during initialization"); }
             _main.PropertyChanged += (s, e) =>
             {
                 if (string.Equals(e.PropertyName, nameof(MainViewModel.IsConnected), StringComparison.Ordinal) ||
                     string.Equals(e.PropertyName, nameof(MainViewModel.Mode), StringComparison.Ordinal))
                 {
-                    try { _readNowCommand.NotifyCanExecuteChanged(); } catch { }
+                    try { _readNowCommand.NotifyCanExecuteChanged(); } catch (Exception ex) { _logger.LogWarning(ex, "Failed to notify CanExecuteChanged on PropertyChanged"); }
                 }
             };
         }
@@ -119,12 +119,12 @@ namespace ModbusForge.ViewModels
 
         private bool CanRead()
         {
-            try { return _main.IsConnected && !IsBusy; } catch { return false; }
+            try { return _main.IsConnected && !IsBusy; } catch (Exception ex) { _logger.LogWarning(ex, "Error checking CanRead status"); return false; }
         }
 
         partial void OnIsBusyChanged(bool value)
         {
-            try { _readNowCommand.NotifyCanExecuteChanged(); } catch { }
+            try { _readNowCommand.NotifyCanExecuteChanged(); } catch (Exception ex) { _logger.LogWarning(ex, "Failed to notify CanExecuteChanged on IsBusy changed"); }
         }
 
         private async Task ReadAsync()


### PR DESCRIPTION
🎯 **What:** Removed empty catch blocks in `DecodeViewModel.cs` and replaced them with proper exception logging (`_logger.LogWarning`).
💡 **Why:** Empty catch blocks silently swallow exceptions, making debugging difficult. Logging the exceptions improves visibility while maintaining the original behavior of preventing application crashes on property or command state changes.
✅ **Verification:** Verified changes by ensuring the project builds successfully and the application logic functions identically. Passed code review.
✨ **Result:** Improved code health and debuggability in `DecodeViewModel`.

---
*PR created automatically by Jules for task [16979624104104602046](https://jules.google.com/task/16979624104104602046) started by @nokkies*