### PR TITLE
🔒 Fix UseShellExecute Vulnerability with Strict URL Validation

### DIFF
--- a/ModbusForge.Tests/Helpers/UrlHelperTests.cs
+++ b/ModbusForge.Tests/Helpers/UrlHelperTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Xunit;
+using ModbusForge.Helpers;
+
+namespace ModbusForge.Tests.Helpers
+{
+    public class UrlHelperTests
+    {
+        [Fact]
+        public void OpenUrl_NullOrEmpty_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => UrlHelper.OpenUrl(null));
+            Assert.Throws<ArgumentException>(() => UrlHelper.OpenUrl(""));
+            Assert.Throws<ArgumentException>(() => UrlHelper.OpenUrl("   "));
+        }
+
+        [Fact]
+        public void OpenUrl_InvalidFormat_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => UrlHelper.OpenUrl("not-a-url"));
+        }
+
+        [Fact]
+        public void OpenUrl_InvalidScheme_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(() => UrlHelper.OpenUrl("file:///C:/Windows/System32/cmd.exe"));
+            Assert.Throws<InvalidOperationException>(() => UrlHelper.OpenUrl("ftp://example.com/file.txt"));
+        }
+
+        // We can't easily test valid URLs without opening a process, which we want to avoid in unit tests.
+        // We could extract the Process.Start call into an interface, but for this simple helper it might be overkill.
+    }
+}

--- a/ModbusForge/AboutWindow.xaml.cs
+++ b/ModbusForge/AboutWindow.xaml.cs
@@ -41,7 +41,7 @@ namespace ModbusForge
         {
             try
             {
-                Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+                ModbusForge.Helpers.UrlHelper.OpenUrl(e.Uri.AbsoluteUri);
             }
             catch (Exception ex)
             {

--- a/ModbusForge/Helpers/UrlHelper.cs
+++ b/ModbusForge/Helpers/UrlHelper.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+
+namespace ModbusForge.Helpers
+{
+    public static class UrlHelper
+    {
+        public static void OpenUrl(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentException("URL cannot be null or empty.", nameof(url));
+            }
+
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+            {
+                throw new ArgumentException("Invalid URL format.", nameof(url));
+            }
+
+            if (uri.Scheme != Uri.UriSchemeHttp &&
+                uri.Scheme != Uri.UriSchemeHttps &&
+                uri.Scheme != Uri.UriSchemeMailto)
+            {
+                throw new InvalidOperationException($"URL scheme '{uri.Scheme}' is not allowed.");
+            }
+
+            Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+        }
+    }
+}

--- a/ModbusForge/MainWindow.xaml.cs
+++ b/ModbusForge/MainWindow.xaml.cs
@@ -57,7 +57,7 @@ namespace ModbusForge
             try
             {
                 var url = "https://www.paypal.com/donate/?hosted_button_id=ELTVNJEYLZE3W";
-                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+                ModbusForge.Helpers.UrlHelper.OpenUrl(url);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the insecure use of `Process.Start` with `UseShellExecute = true` allowing unvalidated URIs to be executed via hyperlinks in `AboutWindow.xaml.cs` and `MainWindow.xaml.cs`.

⚠️ **Risk:** If an attacker managed to inject a malicious URI scheme like `file://`, `cmd://`, or `powershell://` into the payload, it could lead to arbitrary command execution or application access without the user's consent when they click the hyperlink.

🛡️ **Solution:** A new `ModbusForge.Helpers.UrlHelper` class was implemented with an `OpenUrl` method. This centralizes the process startup logic and strictly validates that the URL is absolute and belongs to safe schemes (`http`, `https`, or `mailto`). Both window files were refactored to use this secure helper method, effectively mitigating the command injection and open redirect vulnerability.

---
*PR created automatically by Jules for task [18175464052901139442](https://jules.google.com/task/18175464052901139442) started by @nokkies*