### PR TITLE
🧹 Fix empty catch blocks in ModbusServerService

### DIFF
--- a/ModbusForge/Services/ModbusServerService.cs
+++ b/ModbusForge/Services/ModbusServerService.cs
@@ -84,7 +84,15 @@ namespace ModbusForge.Services
 
         private void CleanupResources()
         {
-            try { _multiServer?.Stop(); } catch { }
+            try
+            {
+                _multiServer?.Stop();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error stopping Modbus server during resource cleanup");
+            }
+
             _multiServer?.Dispose();
             _multiServer = null;
         }
@@ -107,7 +115,7 @@ namespace ModbusForge.Services
             }
         }
 
-        private static string GetLocalNetworkIp()
+        private string GetLocalNetworkIp()
         {
             try
             {
@@ -119,7 +127,10 @@ namespace ModbusForge.Services
                 if (ips.Count > 0)
                     return string.Join(", ", ips);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error resolving local network IP addresses");
+            }
             return "0.0.0.0";
         }
 
@@ -242,7 +253,15 @@ namespace ModbusForge.Services
             {
                 if (disposing)
                 {
-                    try { CleanupResources(); } catch { }
+                    try
+                    {
+                        CleanupResources();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Error during synchronous Dispose");
+                    }
+
                     _isRunning = false;
                 }
                 _disposed = true;


### PR DESCRIPTION
This PR addresses a code health issue in `ModbusServerService.cs` where exceptions in multiple catch blocks were being swallowed without any logging.

### Changes:
- **`CleanupResources`**: Added logging for exceptions occurring during `_multiServer?.Stop()`.
- **`GetLocalNetworkIp`**: Refactored from a `static` to an instance method to enable access to the `_logger` field and added exception logging.
- **`Dispose(bool disposing)`**: Added logging for exceptions occurring during the synchronous cleanup process.

### Impact:
These changes improve the maintainability and observability of the Modbus server component by ensuring that failures during its lifecycle (especially shutdown and IP resolution) are visible to developers and administrators via logs.

### Verification:
- Verified the code changes by reading the modified `ModbusServerService.cs` file.
- Ensured the refactoring of `GetLocalNetworkIp` from static to instance was correctly applied and its call site in `BoundEndpoint` updated accordingly.
- Confirmed that the logic remains correct and respects existing error handling patterns in the codebase.

---
*PR created automatically by Jules for task [3556140252416553976](https://jules.google.com/task/3556140252416553976) started by @nokkies*