### PR TITLE
🧹 [Code Health] Replace NotSupported/NotImplemented exceptions with Binding.DoNothing in WPF Converters

### DIFF
--- a/ModbusForge/Converters/BooleanToConnectedConverter.cs
+++ b/ModbusForge/Converters/BooleanToConnectedConverter.cs
@@ -20,7 +20,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotSupportedException("BooleanToConnectedConverter can only be used for one-way conversion");
+            return Binding.DoNothing;
         }
     }
 }

--- a/ModbusForge/Converters/LockToZoomModeConverter.cs
+++ b/ModbusForge/Converters/LockToZoomModeConverter.cs
@@ -20,7 +20,7 @@ namespace ModbusForge.Converters
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
-            throw new NotSupportedException();
+            return new object[] { Binding.DoNothing, Binding.DoNothing };
         }
     }
 }

--- a/ModbusForge/Converters/VisualNodeConverters.cs
+++ b/ModbusForge/Converters/VisualNodeConverters.cs
@@ -42,7 +42,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -108,7 +108,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -153,7 +153,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -197,7 +197,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced `throw new NotImplementedException()` and `throw new NotSupportedException()` with `return Binding.DoNothing;` across multiple `IValueConverter` and `IMultiValueConverter` implementations in `ModbusForge/Converters`.

💡 **Why:** How this improves maintainability
Throwing exceptions from `ConvertBack` in strictly one-way converters is considered a poor practice in WPF because it can cause runtime crashes if accidentally bound with a `TwoWay` or `OneWayToSource` mode. Returning `Binding.DoNothing` safely instructs the WPF binding engine to abort the property update without crashing, improving robustness.

✅ **Verification:** How you confirmed the change is safe
Ran `dotnet build` successfully with `-p:EnableWindowsTargeting=true`. The replacement strictly pertains to the WPF databinding lifecycle for unhandled/unsupported back-conversions, which preserves the prior application state safely.

✨ **Result:** The improvement achieved
Eliminated 6 instances of code-smell exceptions within converters, conforming to standard WPF/XAML best practices and ensuring application stability.

---
*PR created automatically by Jules for task [15520401759245151281](https://jules.google.com/task/15520401759245151281) started by @nokkies*