### PR TITLE
🧹 Fix unimplemented exceptions in VisualNodeConverters

### DIFF
--- a/ModbusForge/Converters/VisualNodeConverters.cs
+++ b/ModbusForge/Converters/VisualNodeConverters.cs
@@ -42,7 +42,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -108,7 +108,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -153,7 +153,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -197,7 +197,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
🎯 **What:** Replaced `throw new NotImplementedException();` with `return Binding.DoNothing;` in several `ConvertBack` methods within `ModbusForge/Converters/VisualNodeConverters.cs`.

💡 **Why:** These converters are designed for one-way UI bindings (e.g., converting a boolean to a color or an enum to a string tag). By throwing an exception, accidental two-way bindings in XAML would cause the application to crash. Returning `Binding.DoNothing` is the standard WPF convention to ignore the reverse conversion safely while satisfying the `IValueConverter` interface, resolving the unimplemented code smell.

✅ **Verification:** Verified the code builds successfully using `dotnet build -p:EnableWindowsTargeting=true` and verified the logic via code review, which confirmed `Binding.DoNothing` is correct.

✨ **Result:** Improved codebase health and robustness against XAML binding errors without changing intended application behavior.

---
*PR created automatically by Jules for task [4430303275484595585](https://jules.google.com/task/4430303275484595585) started by @nokkies*