### PR TITLE
🧪 [Testing Improvement] Add boundary tests for LoggingSettings.Clamp

### DIFF
--- a/ModbusForge.Tests/Configuration/LoggingSettingsTests.cs
+++ b/ModbusForge.Tests/Configuration/LoggingSettingsTests.cs
@@ -1,0 +1,54 @@
+using Xunit;
+using ModbusForge.Configuration;
+
+namespace ModbusForge.Tests.Configuration
+{
+    public class LoggingSettingsTests
+    {
+        [Theory]
+        [InlineData(0, 1)]      // Below minimum
+        [InlineData(-10, 1)]    // Well below minimum
+        [InlineData(1, 1)]      // Minimum
+        [InlineData(30, 30)]    // Within range
+        [InlineData(60, 60)]    // Maximum
+        [InlineData(61, 60)]    // Above maximum
+        [InlineData(100, 60)]   // Well above maximum
+        public void Clamp_RetentionMinutes_ShouldBeClampedToValidRange(int input, int expected)
+        {
+            // Arrange
+            var settings = new LoggingSettings
+            {
+                RetentionMinutes = input
+            };
+
+            // Act
+            settings.Clamp();
+
+            // Assert
+            Assert.Equal(expected, settings.RetentionMinutes);
+        }
+
+        [Theory]
+        [InlineData(0, 50)]         // Below minimum
+        [InlineData(-100, 50)]      // Well below minimum
+        [InlineData(50, 50)]        // Minimum
+        [InlineData(1000, 1000)]    // Within range
+        [InlineData(60000, 60000)]  // Maximum
+        [InlineData(60001, 60000)]  // Above maximum
+        [InlineData(100000, 60000)] // Well above maximum
+        public void Clamp_SampleRateMs_ShouldBeClampedToValidRange(int input, int expected)
+        {
+            // Arrange
+            var settings = new LoggingSettings
+            {
+                SampleRateMs = input
+            };
+
+            // Act
+            settings.Clamp();
+
+            // Assert
+            Assert.Equal(expected, settings.SampleRateMs);
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `LoggingSettings.Clamp` method logic for capping boundary values was not covered by any unit tests. 

📊 **Coverage:** What scenarios are now tested
1.  **RetentionMinutes:** Values below 1, exactly 1, within the range (e.g., 30), exactly 60, and above 60.
2.  **SampleRateMs:** Values below 50, exactly 50, within the range (e.g., 1000), exactly 60000, and above 60000.

✨ **Result:** The improvement in test coverage
The code handles boundary limits deterministically, and regression safety is secured for the clamp logic via the new test cases in `ModbusForge.Tests/Configuration/LoggingSettingsTests.cs`.

---
*PR created automatically by Jules for task [6909570149485625952](https://jules.google.com/task/6909570149485625952) started by @nokkies*