### PR TITLE
🧪 Add ConnectionProfile clone tests

### DIFF
--- a/ModbusForge.Tests/Models/ConnectionProfileTests.cs
+++ b/ModbusForge.Tests/Models/ConnectionProfileTests.cs
@@ -1,0 +1,71 @@
+using System;
+using ModbusForge.Models;
+using Xunit;
+
+namespace ModbusForge.Tests.Models
+{
+    public class ConnectionProfileTests
+    {
+        [Fact]
+        public void Clone_CopiesCoreProperties()
+        {
+            // Arrange
+            var original = new ConnectionProfile("Test Connection", "192.168.1.100", 5020, 2);
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            Assert.Equal(original.IpAddress, clone.IpAddress);
+            Assert.Equal(original.Port, clone.Port);
+            Assert.Equal(original.UnitId, clone.UnitId);
+        }
+
+        [Fact]
+        public void Clone_AppendsCopyToName()
+        {
+            // Arrange
+            var original = new ConnectionProfile("Test Connection", "192.168.1.100", 5020, 2);
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            Assert.Equal("Test Connection (Copy)", clone.Name);
+        }
+
+        [Fact]
+        public void Clone_GeneratesNewId()
+        {
+            // Arrange
+            var original = new ConnectionProfile("Test Connection", "192.168.1.100", 5020, 2);
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            Assert.NotEqual(original.Id, clone.Id);
+            Assert.True(Guid.TryParse(clone.Id, out _));
+        }
+
+        [Fact]
+        public void Clone_ResetsStateProperties()
+        {
+            // Arrange
+            var original = new ConnectionProfile("Test Connection", "192.168.1.100", 5020, 2)
+            {
+                IsConnected = true,
+                Status = "Connected",
+                IsActive = true
+            };
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            Assert.False(clone.IsConnected);
+            Assert.Equal("Disconnected", clone.Status);
+            Assert.False(clone.IsActive);
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the `ConnectionProfile.Clone()` method in `ModbusForge/Models/ConnectionProfile.cs` have been addressed.

📊 **Coverage:** Unit tests cover:
- Correct copying of `IpAddress`, `Port`, and `UnitId` core properties.
- Proper appending of " (Copy)" to the `Name`.
- Correct generation of a new unique `Id` on clone.
- Verification that transient state properties (`IsConnected`, `Status`, `IsActive`) are reset correctly in the new instance.

✨ **Result:** Enhanced test coverage provides a safety net ensuring that future modifications to `ConnectionProfile` or the cloning behavior do not inadvertently duplicate unique IDs or copy runtime transient states.

---
*PR created automatically by Jules for task [14788993554817070508](https://jules.google.com/task/14788993554817070508) started by @nokkies*