### PR TITLE
🧪 Test for ConnectionManager.AddProfile

### DIFF
--- a/ModbusForge.Tests/Services/ConnectionManagerTests.cs
+++ b/ModbusForge.Tests/Services/ConnectionManagerTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using ModbusForge.Models;
+using ModbusForge.Services;
+using Moq;
+using Xunit;
+
+namespace ModbusForge.Tests.Services;
+
+public class ConnectionManagerTests
+{
+    private readonly Mock<ILogger<ConnectionManager>> _mockLogger;
+    private readonly Mock<ILoggerFactory> _mockLoggerFactory;
+    private readonly ConnectionManager _manager;
+
+    public ConnectionManagerTests()
+    {
+        _mockLogger = new Mock<ILogger<ConnectionManager>>();
+        _mockLoggerFactory = new Mock<ILoggerFactory>();
+        _mockLoggerFactory
+            .Setup(f => f.CreateLogger(It.IsAny<string>()))
+            .Returns(new Mock<ILogger>().Object);
+
+        _manager = new ConnectionManager(_mockLogger.Object, _mockLoggerFactory.Object);
+
+        // Remove default profiles added by constructor to start fresh for tests
+        foreach (var profile in _manager.Profiles.ToList())
+        {
+            _manager.RemoveProfile(profile);
+        }
+        _manager.SetActiveProfile(null!);
+    }
+
+    [Fact]
+    public void AddProfile_AddsProfileToCollection()
+    {
+        // Arrange
+        var profile = new ConnectionProfile("Test", "127.0.0.1", 502, 1);
+
+        // Act
+        _manager.AddProfile(profile);
+
+        // Assert
+        Assert.Contains(profile, _manager.Profiles);
+    }
+
+    [Fact]
+    public void AddProfile_WhenActiveProfileIsNull_SetsActiveProfile()
+    {
+        // Arrange
+        var profile = new ConnectionProfile("Test", "127.0.0.1", 502, 1);
+        Assert.Null(_manager.ActiveProfile);
+
+        // Act
+        _manager.AddProfile(profile);
+
+        // Assert
+        Assert.Equal(profile, _manager.ActiveProfile);
+        Assert.True(profile.IsActive);
+    }
+
+    [Fact]
+    public void AddProfile_WhenActiveProfileIsNotNull_DoesNotChangeActiveProfile()
+    {
+        // Arrange
+        var firstProfile = new ConnectionProfile("First", "127.0.0.1", 502, 1);
+        var secondProfile = new ConnectionProfile("Second", "127.0.0.1", 502, 1);
+
+        _manager.AddProfile(firstProfile);
+        Assert.Equal(firstProfile, _manager.ActiveProfile);
+
+        // Act
+        _manager.AddProfile(secondProfile);
+
+        // Assert
+        Assert.Equal(firstProfile, _manager.ActiveProfile);
+        Assert.True(firstProfile.IsActive);
+        Assert.False(secondProfile.IsActive);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This pull request adds unit testing for the `AddProfile` logic within `ConnectionManager`. It verifies correct functionality for profile addition to the internal collection and ensures correct active profile behaviors via mocked dependencies.

📊 **Coverage:** What scenarios are now tested
- Validates the new profile is appended to the internal `Profiles` collection.
- Tests that adding a profile successfully sets it as active if `_activeProfile` is presently null.
- Tests that adding a new profile leaves an existing active profile correctly active and avoids modification when `_activeProfile` is previously populated.

✨ **Result:** The improvement in test coverage
The logic covering adding connection profiles in `ConnectionManager` is now fully tested across all happy and isolated paths, reducing regression risks with DI setup using xUnit and Moq frameworks.

---
*PR created automatically by Jules for task [2739525355970002272](https://jules.google.com/task/2739525355970002272) started by @nokkies*