### PR TITLE
🧪 [testing improvement] Add explicit value tests to DataTypeConverter

### DIFF
--- a/ModbusForge.Tests/Helpers/DataTypeConverterTests.cs
+++ b/ModbusForge.Tests/Helpers/DataTypeConverterTests.cs
@@ -7,6 +7,35 @@ namespace ModbusForge.Tests.Helpers
     public class DataTypeConverterTests
     {
         [Theory]
+        [InlineData(0x3F80, 0x0000, 1.0f)]
+        [InlineData(0xBF80, 0x0000, -1.0f)]
+        [InlineData(0x0000, 0x0000, 0.0f)]
+        [InlineData(0x42F6, 0xE979, 123.456f)] // ~123.456
+        public void ToSingle_ExplicitRegisters_ReturnsExpectedFloat(ushort high, ushort low, float expected)
+        {
+            // Act
+            float result = DataTypeConverter.ToSingle(high, low);
+
+            // Assert
+            // Use precision 3 for 123.456f test as floats are imprecise
+            Assert.Equal(expected, result, 3);
+        }
+
+        [Theory]
+        [InlineData(1.0f, new ushort[] { 0x3F80, 0x0000 })]
+        [InlineData(-1.0f, new ushort[] { 0xBF80, 0x0000 })]
+        [InlineData(0.0f, new ushort[] { 0x0000, 0x0000 })]
+        [InlineData(123.456f, new ushort[] { 0x42F6, 0xE979 })]
+        public void ToUInt16_ExplicitFloat_ReturnsExpectedRegisters(float input, ushort[] expected)
+        {
+            // Act
+            ushort[] result = DataTypeConverter.ToUInt16(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
         [InlineData(1.0f)]
         [InlineData(0.0f)]
         [InlineData(-1.0f)]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `DataTypeConverter` only had round-trip tests for floating point conversions, which could mask bugs like endianness inversions if both `ToSingle` and `ToUInt16` shared the same flaw.
  📊 **Coverage:** Explicit scenarios mapping hardcoded `float` values (1.0f, -1.0f, 0.0f, 123.456f) to exact Big-Endian `ushort` registers (and vice-versa) are now explicitly tested.
  ✨ **Result:** Enhanced test coverage that explicitly verifies byte ordering adherence rather than just mathematical inversion.

---
*PR created automatically by Jules for task [1632114372937239183](https://jules.google.com/task/1632114372937239183) started by @nokkies*