### PR TITLE
🧹 [Code Health] Fix NotImplementedException in VisualNodeConverters

### DIFF
--- a/ModbusForge/Converters/VisualNodeConverters.cs
+++ b/ModbusForge/Converters/VisualNodeConverters.cs
@@ -42,7 +42,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -108,7 +108,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -153,7 +153,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 
@@ -197,7 +197,7 @@ namespace ModbusForge.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
🎯 **What:** Replaced `throw new NotImplementedException();` with `return Binding.DoNothing;` in the `ConvertBack` methods of `BoolToDashArrayConverter`, `PlcElementTypeToColorConverter`, `PlcElementTypeToIconConverter`, and `ConnectorTagConverter` inside `ModbusForge/Converters/VisualNodeConverters.cs`.

💡 **Why:** These converters are intended for one-way bindings. Leaving `NotImplementedException` in the codebase is a code smell and can cause application crashes if a UI element mistakenly triggers a `TwoWay` binding update. Returning `Binding.DoNothing` is the standard and safe WPF practice for signaling that the reverse conversion is intentionally unsupported without raising an exception.

✅ **Verification:** Verified by compiling the application. Examined the modified file to ensure no `NotImplementedException` calls remained. Code review approved the changes.

✨ **Result:** Improved maintainability, cleaner code, and increased resilience against potential UI binding errors.

---
*PR created automatically by Jules for task [14900313487852817043](https://jules.google.com/task/14900313487852817043) started by @nokkies*