### PR TITLE
🧪 Add testing and reliability improvements for SettingsService.Save

### DIFF
--- a/ModbusForge.Tests/Services/SettingsServiceTests.cs
+++ b/ModbusForge.Tests/Services/SettingsServiceTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ModbusForge.Services;
+using Moq;
+using Xunit;
+
+namespace ModbusForge.Tests.Services
+{
+    public class SettingsServiceTests : IDisposable
+    {
+        private readonly Mock<ILogger<SettingsService>> _mockLogger;
+        private readonly string _tempDirectory;
+        private readonly string _tempFilePath;
+
+        public SettingsServiceTests()
+        {
+            _mockLogger = new Mock<ILogger<SettingsService>>();
+            _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            _tempFilePath = Path.Combine(_tempDirectory, "settings.json");
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                try
+                {
+                    Directory.Delete(_tempDirectory, true);
+                }
+                catch
+                {
+                    // Ignore errors during test cleanup
+                }
+            }
+        }
+
+        [Fact]
+        public void Save_ShouldReturnTrueAndWriteFile_WhenSuccessful()
+        {
+            // Arrange
+            var service = new SettingsService(_tempFilePath, _mockLogger.Object);
+            service.AutoReconnect = true;
+            service.AutoReconnectIntervalMs = 1234;
+
+            // Act
+            var result = service.Save();
+
+            // Assert
+            Assert.True(result);
+            Assert.True(File.Exists(_tempFilePath));
+
+            var json = File.ReadAllText(_tempFilePath);
+            Assert.Contains("\"AutoReconnect\": true", json);
+            Assert.Contains("\"AutoReconnectIntervalMs\": 1234", json);
+        }
+
+        [Fact]
+        public void Save_ShouldReturnFalseAndLog_WhenFilePathIsInvalid()
+        {
+            // Arrange
+            // Create a path that is known to cause a directory/file system exception across OS environments.
+            // Using an empty string for the file name typically causes an ArgumentException or similar when attempting to save.
+            string invalidPath = "";
+            var service = new SettingsService(invalidPath, _mockLogger.Object);
+
+            // Act
+            var result = service.Save();
+
+            // Assert
+            Assert.False(result);
+
+            // Verify that logger was called with an error
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => true),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)),
+                Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public void Load_ShouldLoadSettingsFromFile_WhenFileExists()
+        {
+            // Arrange
+            Directory.CreateDirectory(_tempDirectory);
+            var initialJson = "{\"AutoReconnect\": true, \"AutoReconnectIntervalMs\": 5678, \"ShowConnectionDiagnosticsOnError\": false, \"ConfirmOnExit\": true, \"EnableConsoleLogging\": false, \"MaxConsoleMessages\": 500}";
+            File.WriteAllText(_tempFilePath, initialJson);
+
+            // Act
+            var service = new SettingsService(_tempFilePath, _mockLogger.Object);
+
+            // Assert
+            Assert.True(service.AutoReconnect);
+            Assert.Equal(5678, service.AutoReconnectIntervalMs);
+            Assert.False(service.ShowConnectionDiagnosticsOnError);
+            Assert.True(service.ConfirmOnExit);
+            Assert.False(service.EnableConsoleLogging);
+            Assert.Equal(500, service.MaxConsoleMessages);
+        }
+
+        [Fact]
+        public void Load_ShouldUseDefaults_WhenFileDoesNotExist()
+        {
+            // Arrange
+            // Ensure file does not exist
+            if (File.Exists(_tempFilePath))
+            {
+                File.Delete(_tempFilePath);
+            }
+
+            // Act
+            var service = new SettingsService(_tempFilePath, _mockLogger.Object);
+
+            // Assert (verify defaults)
+            Assert.False(service.AutoReconnect);
+            Assert.Equal(5000, service.AutoReconnectIntervalMs);
+            Assert.True(service.ShowConnectionDiagnosticsOnError);
+            Assert.False(service.ConfirmOnExit);
+            Assert.True(service.EnableConsoleLogging);
+            Assert.Equal(1000, service.MaxConsoleMessages);
+        }
+
+        [Fact]
+        public void Load_ShouldUseDefaultsAndLog_WhenFileContainsInvalidJson()
+        {
+            // Arrange
+            Directory.CreateDirectory(_tempDirectory);
+            File.WriteAllText(_tempFilePath, "Invalid JSON data {");
+
+            // Act
+            var service = new SettingsService(_tempFilePath, _mockLogger.Object);
+
+            // Assert
+            Assert.False(service.AutoReconnect); // Default
+            Assert.Equal(5000, service.AutoReconnectIntervalMs); // Default
+
+            // Verify logger was called
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => true),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)),
+                Times.Once);
+        }
+    }
+}

--- a/ModbusForge/PreferencesWindow.xaml.cs
+++ b/ModbusForge/PreferencesWindow.xaml.cs
@@ -58,9 +58,19 @@ public partial class PreferencesWindow : MetroWindow
             _settingsService.ApiPort = apiPort;
         }
 
-        _settingsService.Save();
-        DialogResult = true;
-        Close();
+        if (_settingsService.Save())
+        {
+            DialogResult = true;
+            Close();
+        }
+        else
+        {
+            System.Windows.MessageBox.Show(
+                "Failed to save settings. Please check your permissions or disk space.",
+                "Error",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
     }
 
     private void CancelButton_Click(object sender, System.Windows.RoutedEventArgs e)

--- a/ModbusForge/Services/ISettingsService.cs
+++ b/ModbusForge/Services/ISettingsService.cs
@@ -24,7 +24,7 @@ public interface ISettingsService
     int MaxConcurrentTrendRequests { get; set; }
 
     // Save/Load
-    void Save();
+    bool Save();
     void Load();
     
     // Event for settings changed

--- a/ModbusForge/Services/SettingsService.cs
+++ b/ModbusForge/Services/SettingsService.cs
@@ -1,15 +1,14 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace ModbusForge.Services;
 
 public class SettingsService : ISettingsService
 {
-    private static readonly string SettingsFilePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "ModbusForge",
-        "settings.json");
+    private readonly string _settingsFilePath;
+    private readonly ILogger<SettingsService>? _logger;
 
     private SettingsData _settings = new();
 
@@ -69,27 +68,36 @@ public class SettingsService : ISettingsService
 
     public event EventHandler? SettingsChanged;
 
-    public SettingsService()
+    public SettingsService(ILogger<SettingsService>? logger = null)
+        : this(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ModbusForge", "settings.json"), logger)
     {
+    }
+
+    internal SettingsService(string settingsFilePath, ILogger<SettingsService>? logger = null)
+    {
+        _settingsFilePath = settingsFilePath;
+        _logger = logger;
         Load();
     }
 
-    public void Save()
+    public bool Save()
     {
         try
         {
-            var directory = Path.GetDirectoryName(SettingsFilePath);
+            var directory = Path.GetDirectoryName(_settingsFilePath);
             if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
             {
                 Directory.CreateDirectory(directory);
             }
 
             var json = JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(SettingsFilePath, json);
+            File.WriteAllText(_settingsFilePath, json);
+            return true;
         }
-        catch
+        catch (Exception ex)
         {
-            // Silently fail if we can't save settings
+            _logger?.LogError(ex, "Failed to save settings to {FilePath}", _settingsFilePath);
+            return false;
         }
     }
 
@@ -97,9 +105,9 @@ public class SettingsService : ISettingsService
     {
         try
         {
-            if (File.Exists(SettingsFilePath))
+            if (File.Exists(_settingsFilePath))
             {
-                var json = File.ReadAllText(SettingsFilePath);
+                var json = File.ReadAllText(_settingsFilePath);
                 var loaded = JsonSerializer.Deserialize<SettingsData>(json);
                 if (loaded != null)
                 {
@@ -107,8 +115,9 @@ public class SettingsService : ISettingsService
                 }
             }
         }
-        catch
+        catch (Exception ex)
         {
+            _logger?.LogError(ex, "Failed to load settings from {FilePath}", _settingsFilePath);
             // Use defaults if we can't load
             _settings = new SettingsData();
         }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `SettingsService.Save()` method, which performs file I/O operations and previously failed silently if an error occurred.

📊 **Coverage:** The new `SettingsServiceTests` now verify:
- Successful file saving with correct JSON serialization.
- Failed saves when encountering invalid file paths (logging the error and returning false).
- Successful file loading.
- Loading fallback to default settings when the file does not exist or contains invalid JSON.

✨ **Result:** The `SettingsService` is now robust, testable, and prevents silent failures by utilizing `ILogger` and returning success status. The `PreferencesWindow` actively responds to save failures, significantly improving the application's code quality and UX reliability.

---
*PR created automatically by Jules for task [7735441092457626629](https://jules.google.com/task/7735441092457626629) started by @nokkies*