### PR TITLE
🧹 [MainViewModel] Fix empty catch block in SubscribeCustomEntries

### DIFF
--- a/ModbusForge/ViewModels/MainViewModel.cs
+++ b/ModbusForge/ViewModels/MainViewModel.cs
@@ -1218,7 +1218,10 @@ namespace ModbusForge.ViewModels
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error subscribing to custom entries");
+            }
         }
 
         private void CustomEntries_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
🎯 **What:** Replaced an empty `catch { }` block in `MainViewModel.SubscribeCustomEntries` with a logged warning.
💡 **Why:** Improves maintainability and observability by ensuring that any exceptions occurring during custom entry subscription or trend registration are documented in the logs rather than failing silently.
✅ **Verification:** Manually verified the change in `MainViewModel.cs`. The fix follows existing logging patterns in the codebase and was confirmed as correct during code review.
✨ **Result:** Enhanced diagnostic capability for issues related to custom entry event handling and trend registration.

---
*PR created automatically by Jules for task [9704804604236115255](https://jules.google.com/task/9704804604236115255) started by @nokkies*