### PR TITLE
Fix C# nullability warnings across ViewModels and Services

### DIFF
--- a/ModbusForge/Services/VisualSimulationService.cs
+++ b/ModbusForge/Services/VisualSimulationService.cs
@@ -610,9 +610,9 @@ namespace ModbusForge.Services
             return address.Not ? (value == 0 ? 1 : 0) : value;
         }
 
-        private void WriteModbusValue(PlcAddressReference output, ushort value, DataStore dataStore)
+        private void WriteModbusValue(PlcAddressReference? output, ushort value, DataStore dataStore)
         {
-            if (output?.Address < 0) return;
+            if (output == null || output.Address < 0) return;
 
             var finalValue = output.Not ? (value == 0 ? (ushort)1 : (ushort)0) : value;
 

--- a/ModbusForge/ViewModels/MainViewModel.cs
+++ b/ModbusForge/ViewModels/MainViewModel.cs
@@ -40,7 +40,8 @@ namespace ModbusForge.ViewModels
         partial void OnRegistersGlobalTypeChanged(string value);
         partial void OnInputRegistersGlobalTypeChanged(string value);
 
-        private IModbusService _modbusService;
+        // Initialized in InitializeServiceState called from constructor
+        private IModbusService _modbusService = null!;
         private readonly ModbusTcpService _clientService;
         private readonly ModbusServerService _serverService;
         private readonly IConsoleLoggerService _consoleLoggerService;
@@ -385,9 +386,12 @@ namespace ModbusForge.ViewModels
 
         private IRelayCommand? _disconnectCommand;
         private readonly ILogger<MainViewModel> _logger;
-        private DispatcherTimer _customTimer;
-        private DispatcherTimer _monitorTimer;
-        private DispatcherTimer _trendTimer;
+        // Timers initialized in InitializeTimersAndServices called from constructor
+        private DispatcherTimer _customTimer = null!;
+        // Timers initialized in InitializeTimersAndServices called from constructor
+        private DispatcherTimer _monitorTimer = null!;
+        // Timers initialized in InitializeTimersAndServices called from constructor
+        private DispatcherTimer _trendTimer = null!;
         private readonly ITrendLogger _trendLogger;
         private readonly ICustomEntryService _customEntryService;
         private bool _isMonitoring;

--- a/ModbusForge/Views/VisualNodeEditor.xaml.cs
+++ b/ModbusForge/Views/VisualNodeEditor.xaml.cs
@@ -163,7 +163,10 @@ namespace ModbusForge.Views
         {
             if (_isConnecting)
             {
-                _viewModel.PendingConnectionStart = null;
+                if (_viewModel != null)
+                {
+                    _viewModel.PendingConnectionStart = null;
+                }
                 TempConnectionLine.Visibility = Visibility.Collapsed;
                 _isConnecting = false;
                 
@@ -200,7 +203,7 @@ namespace ModbusForge.Views
             return position;
         }
         
-        private T FindParent<T>(DependencyObject child) where T : DependencyObject
+        private T? FindParent<T>(DependencyObject child) where T : DependencyObject
         {
             DependencyObject parentObject = VisualTreeHelper.GetParent(child);
             
@@ -270,7 +273,7 @@ namespace ModbusForge.Views
             }
         }
         
-        private void Connections_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        private void Connections_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             RefreshConnections();
         }
@@ -1257,7 +1260,7 @@ namespace ModbusForge.Views
             return CalculateConnectorPosition(nodeId, connectorType);
         }
         
-        private Ellipse FindConnectorInNode(Border nodeBorder, string connectorType)
+        private Ellipse? FindConnectorInNode(Border nodeBorder, string connectorType)
         {
             // Recursively search the visual tree for an Ellipse tagged with the connector type
             return FindEllipseByTag(nodeBorder, connectorType);


### PR DESCRIPTION
Resolves the 18 specific nullability warnings (CS8602, CS8603, CS8618, CS8622) in `MainViewModel.cs`, `VisualNodeEditor.xaml.cs`, and `VisualSimulationService.cs`. The changes correctly suppress via `!` for fields guaranteed initialized by constructor-called methods, or via explicit nullable return types and proper parameter signatures. Tests and compilation confirm 0 remaining warnings.

---
*PR created automatically by Jules for task [15163884464187459207](https://jules.google.com/task/15163884464187459207) started by @nokkies*