### PR TITLE
Add search filter to visual node editor palette

### DIFF
--- a/ModbusForge.Tests/ViewModels/NodePaletteFilterTests.cs
+++ b/ModbusForge.Tests/ViewModels/NodePaletteFilterTests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using ModbusForge.ViewModels;
+using Xunit;
+
+namespace ModbusForge.Tests.ViewModels
+{
+    public class NodePaletteFilterTests
+    {
+        [Fact]
+        public void SearchEmpty_ShowsAllNodes()
+        {
+            // Arrange
+            var viewModel = new VisualNodeEditorViewModel();
+
+            // Act
+            viewModel.SearchText = "";
+
+            // Assert
+            Assert.All(viewModel.PaletteCategories, c => Assert.True(c.IsVisible));
+            Assert.All(viewModel.PaletteCategories.SelectMany(c => c.Nodes), n => Assert.True(n.IsVisible));
+        }
+
+        [Fact]
+        public void SearchSubstring_MatchesNodeNameOrCategory()
+        {
+            // Arrange
+            var viewModel = new VisualNodeEditorViewModel();
+
+            // Act
+            viewModel.SearchText = "timer";
+
+            // Assert
+            var timersCategory = viewModel.PaletteCategories.FirstOrDefault(c => c.Name == "Timers");
+            var ioCategory = viewModel.PaletteCategories.FirstOrDefault(c => c.Name == "I/O");
+
+            Assert.NotNull(timersCategory);
+            Assert.True(timersCategory.IsVisible);
+            Assert.All(timersCategory.Nodes, n => Assert.True(n.IsVisible)); // TON, TOF, TP all have "Timer" in name
+
+            Assert.NotNull(ioCategory);
+            Assert.False(ioCategory.IsVisible);
+            Assert.All(ioCategory.Nodes, n => Assert.False(n.IsVisible));
+        }
+
+        [Fact]
+        public void SearchCaseInsensitive_Matches()
+        {
+            // Arrange
+            var viewModel = new VisualNodeEditorViewModel();
+
+            // Act
+            viewModel.SearchText = "mAtH";
+
+            // Assert
+            var mathCategory = viewModel.PaletteCategories.FirstOrDefault(c => c.Name == "Math Operations");
+            Assert.NotNull(mathCategory);
+            Assert.True(mathCategory.IsVisible);
+            Assert.All(mathCategory.Nodes, n => Assert.True(n.IsVisible)); // All match because category matches
+
+            var logicCategory = viewModel.PaletteCategories.FirstOrDefault(c => c.Name == "Logic Gates");
+            Assert.NotNull(logicCategory);
+            Assert.False(logicCategory.IsVisible);
+        }
+
+        [Fact]
+        public void SearchNoMatch_ShowsEmpty()
+        {
+            // Arrange
+            var viewModel = new VisualNodeEditorViewModel();
+
+            // Act
+            viewModel.SearchText = "xyz123";
+
+            // Assert
+            Assert.All(viewModel.PaletteCategories, c => Assert.False(c.IsVisible));
+            Assert.All(viewModel.PaletteCategories.SelectMany(c => c.Nodes), n => Assert.False(n.IsVisible));
+        }
+
+        [Fact]
+        public void SearchClear_RestoresAll()
+        {
+            // Arrange
+            var viewModel = new VisualNodeEditorViewModel();
+            viewModel.SearchText = "logic";
+
+            // Verify it filtered
+            Assert.Contains(viewModel.PaletteCategories, c => !c.IsVisible);
+
+            // Act
+            viewModel.SearchText = "";
+
+            // Assert
+            Assert.All(viewModel.PaletteCategories, c => Assert.True(c.IsVisible));
+            Assert.All(viewModel.PaletteCategories.SelectMany(c => c.Nodes), n => Assert.True(n.IsVisible));
+        }
+    }
+}

--- a/ModbusForge/ViewModels/VisualNodeEditorViewModel.cs
+++ b/ModbusForge/ViewModels/VisualNodeEditorViewModel.cs
@@ -10,6 +10,29 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ModbusForge.ViewModels
 {
+    public partial class PaletteNode : ObservableObject
+    {
+        [ObservableProperty]
+        private string _name = string.Empty;
+
+        [ObservableProperty]
+        private string _tag = string.Empty;
+
+        [ObservableProperty]
+        private bool _isVisible = true;
+    }
+
+    public partial class PaletteCategory : ObservableObject
+    {
+        [ObservableProperty]
+        private string _name = string.Empty;
+
+        [ObservableProperty]
+        private bool _isVisible = true;
+
+        public ObservableCollection<PaletteNode> Nodes { get; set; } = new ObservableCollection<PaletteNode>();
+    }
+
     public partial class VisualNodeEditorViewModel : ViewModelBase
     {
         [ObservableProperty]
@@ -63,12 +86,130 @@ namespace ModbusForge.ViewModels
         [ObservableProperty]
         private string _newProgramName = "New Program";
         
+        [ObservableProperty]
+        private string _searchText = "";
+
+        public ObservableCollection<PaletteCategory> PaletteCategories { get; } = new ObservableCollection<PaletteCategory>();
+
         public VisualNodeEditorViewModel()
         {
             // Initialize with a default program
             var defaultProgram = new ProgramModel { Name = "Main", ExecutionOrder = 0 };
             ProgramTree.Programs.Add(defaultProgram);
             SelectedProgram = defaultProgram;
+
+            InitializePalette();
+        }
+
+        private void InitializePalette()
+        {
+            PaletteCategories.Add(new PaletteCategory
+            {
+                Name = "I/O",
+                Nodes = new ObservableCollection<PaletteNode>
+                {
+                    new PaletteNode { Name = "Input BOOL", Tag = "InputBool" },
+                    new PaletteNode { Name = "Input INT", Tag = "InputInt" },
+                    new PaletteNode { Name = "Output BOOL", Tag = "OutputBool" },
+                    new PaletteNode { Name = "Output INT", Tag = "OutputInt" }
+                }
+            });
+
+            PaletteCategories.Add(new PaletteCategory
+            {
+                Name = "Logic Gates",
+                Nodes = new ObservableCollection<PaletteNode>
+                {
+                    new PaletteNode { Name = "AND Gate", Tag = "AND" },
+                    new PaletteNode { Name = "OR Gate", Tag = "OR" },
+                    new PaletteNode { Name = "NOT Gate", Tag = "NOT" },
+                    new PaletteNode { Name = "RS Latch", Tag = "RS" }
+                }
+            });
+
+            PaletteCategories.Add(new PaletteCategory
+            {
+                Name = "Timers",
+                Nodes = new ObservableCollection<PaletteNode>
+                {
+                    new PaletteNode { Name = "TON Timer", Tag = "TON" },
+                    new PaletteNode { Name = "TOF Timer", Tag = "TOF" },
+                    new PaletteNode { Name = "TP Timer", Tag = "TP" }
+                }
+            });
+
+            PaletteCategories.Add(new PaletteCategory
+            {
+                Name = "Counters",
+                Nodes = new ObservableCollection<PaletteNode>
+                {
+                    new PaletteNode { Name = "CTU Counter", Tag = "CTU" },
+                    new PaletteNode { Name = "CTD Counter", Tag = "CTD" },
+                    new PaletteNode { Name = "CTC Counter", Tag = "CTC" }
+                }
+            });
+
+            PaletteCategories.Add(new PaletteCategory
+            {
+                Name = "Comparators",
+                Nodes = new ObservableCollection<PaletteNode>
+                {
+                    new PaletteNode { Name = "Equal (==)", Tag = "COMPARE_EQ" },
+                    new PaletteNode { Name = "Not Equal (!=)", Tag = "COMPARE_NE" },
+                    new PaletteNode { Name = "Greater Than (>)", Tag = "COMPARE_GT" },
+                    new PaletteNode { Name = "Less Than (<)", Tag = "COMPARE_LT" },
+                    new PaletteNode { Name = "Greater Equal (>=)", Tag = "COMPARE_GE" },
+                    new PaletteNode { Name = "Less Equal (<=)", Tag = "COMPARE_LE" }
+                }
+            });
+
+            PaletteCategories.Add(new PaletteCategory
+            {
+                Name = "Math Operations",
+                Nodes = new ObservableCollection<PaletteNode>
+                {
+                    new PaletteNode { Name = "Add (+)", Tag = "MATH_ADD" },
+                    new PaletteNode { Name = "Subtract (-)", Tag = "MATH_SUB" },
+                    new PaletteNode { Name = "Multiply (*)", Tag = "MATH_MUL" },
+                    new PaletteNode { Name = "Divide (/)", Tag = "MATH_DIV" }
+                }
+            });
+        }
+
+        [RelayCommand]
+        private void ClearSearch()
+        {
+            SearchText = "";
+            System.Windows.Input.Keyboard.ClearFocus();
+        }
+
+        partial void OnSearchTextChanged(string value)
+        {
+            bool isEmpty = string.IsNullOrWhiteSpace(value);
+
+            foreach (var category in PaletteCategories)
+            {
+                bool anyVisible = false;
+
+                foreach (var node in category.Nodes)
+                {
+                    if (isEmpty)
+                    {
+                        node.IsVisible = true;
+                        anyVisible = true;
+                    }
+                    else
+                    {
+                        bool matches = node.Name.Contains(value!, StringComparison.OrdinalIgnoreCase) ||
+                                       node.Tag.Contains(value!, StringComparison.OrdinalIgnoreCase) ||
+                                       category.Name.Contains(value!, StringComparison.OrdinalIgnoreCase);
+                        node.IsVisible = matches;
+                        if (matches) anyVisible = true;
+                    }
+                }
+
+                category.IsVisible = anyVisible;
+            }
         }
         
         private void InitializeSampleNodes()

--- a/ModbusForge/Views/VisualNodeEditor.xaml
+++ b/ModbusForge/Views/VisualNodeEditor.xaml
@@ -188,137 +188,45 @@
                 <StackPanel Margin="10" Orientation="Vertical">
                     <TextBlock Text="Node Palette" FontWeight="Bold" Margin="0,0,0,10" FontSize="14"/>
                     
-                    <!-- I/O Section -->
-                    <Expander Header="I/O" IsExpanded="True" Margin="0,5">
-                        <StackPanel Margin="0,5,0,0">
-                            <Button Content="Input BOOL" Tag="InputBool" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Input INT" Tag="InputInt" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Output BOOL" Tag="OutputBool" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Output INT" Tag="OutputInt" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                        </StackPanel>
-                    </Expander>
+                    <Grid Margin="0,0,0,10">
+                        <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                                 mah:TextBoxHelper.Watermark="Search nodes..."
+                                 mah:TextBoxHelper.ClearTextButton="True">
+                            <TextBox.InputBindings>
+                                <KeyBinding Key="Esc" Command="{Binding ClearSearchCommand}" />
+                            </TextBox.InputBindings>
+                        </TextBox>
+                    </Grid>
                     
-                    <!-- Logic Gates Section -->
-                    <Expander Header="Logic Gates" IsExpanded="True" Margin="0,5">
-                        <StackPanel Margin="0,5,0,0">
-                            <Button Content="AND Gate" Tag="AND" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="OR Gate" Tag="OR" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="NOT Gate" Tag="NOT" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="RS Latch" Tag="RS" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                        </StackPanel>
-                    </Expander>
-                    
-                    <!-- Timers Section -->
-                    <Expander Header="Timers" IsExpanded="True" Margin="0,5">
-                        <StackPanel Margin="0,5,0,0">
-                            <Button Content="TON Timer" Tag="TON" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="TOF Timer" Tag="TOF" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="TP Timer" Tag="TP" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                        </StackPanel>
-                    </Expander>
-                    
-                    <!-- Counters Section -->
-                    <Expander Header="Counters" IsExpanded="True" Margin="0,5">
-                        <StackPanel Margin="0,5,0,0">
-                            <Button Content="CTU Counter" Tag="CTU" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="CTD Counter" Tag="CTD" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="CTC Counter" Tag="CTC" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                        </StackPanel>
-                    </Expander>
-                    
-                    <!-- Comparators Section -->
-                    <Expander Header="Comparators" IsExpanded="True" Margin="0,5">
-                        <StackPanel Margin="0,5,0,0">
-                            <Button Content="Equal (==)" Tag="COMPARE_EQ" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Not Equal (!=)" Tag="COMPARE_NE" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Greater Than (&gt;)" Tag="COMPARE_GT" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Less Than (&lt;)" Tag="COMPARE_LT" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Greater Equal (&gt;=)" Tag="COMPARE_GE" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Less Equal (&lt;=)" Tag="COMPARE_LE" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                        </StackPanel>
-                    </Expander>
-                    
-                    <!-- Math Operations Section -->
-                    <Expander Header="Math Operations" IsExpanded="True" Margin="0,5">
-                        <StackPanel Margin="0,5,0,0">
-                            <Button Content="Add (+)" Tag="MATH_ADD" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Subtract (-)" Tag="MATH_SUB" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Multiply (*)" Tag="MATH_MUL" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                            <Button Content="Divide (/)" Tag="MATH_DIV" Margin="0,2,0,2" Padding="8,4"
-                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                    Background="#F0F0F0" BorderBrush="#C8C8C8" BorderThickness="1"
-                                    Command="{Binding AddNodeCommand}" CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
-                        </StackPanel>
-                    </Expander>
+                    <ItemsControl ItemsSource="{Binding PaletteCategories}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Expander Header="{Binding Name}"
+                                          Visibility="{Binding IsVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+                                          IsExpanded="True"
+                                          Margin="0,5">
+                                    <ItemsControl ItemsSource="{Binding Nodes}" Margin="0,5,0,0">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Button Content="{Binding Name}"
+                                                        Tag="{Binding Tag}"
+                                                        Command="{Binding DataContext.AddNodeCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                        CommandParameter="{Binding Tag}"
+                                                        Visibility="{Binding IsVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                        Margin="0,2,0,2"
+                                                        Padding="8,4"
+                                                        HorizontalAlignment="Stretch"
+                                                        HorizontalContentAlignment="Left"
+                                                        Background="#F0F0F0"
+                                                        BorderBrush="#C8C8C8"
+                                                        BorderThickness="1"/>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </Expander>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
             </ScrollViewer>
         </Border>


### PR DESCRIPTION
This PR adds a search/filter box at the top of the node palette in the Visual Node Editor, enabling users to easily find specific node types among the 50+ available options without excessive scrolling.

### Changes Made:
1. **ViewModel (`VisualNodeEditorViewModel.cs`)**:
   - Introduced `PaletteNode` and `PaletteCategory` classes.
   - Initialized an `ObservableCollection<PaletteCategory> PaletteCategories` containing all the original node data.
   - Added `SearchText` property utilizing `CommunityToolkit.Mvvm`.
   - Added `OnSearchTextChanged` to execute case-insensitive substring matches against node names, tags, and category names, updating visibility in real time.
   - Added a `ClearSearchCommand` to clear the filter and reset focus.

2. **View (`VisualNodeEditor.xaml`)**:
   - Replaced static `Expander` blocks with nested `ItemsControl` structures dynamically bound to `PaletteCategories`.
   - Added a `TextBox` for searching at the top of the palette panel, configured with `mah:TextBoxHelper.Watermark` and `mah:TextBoxHelper.ClearTextButton`.
   - Added `KeyBinding` for the `Esc` key to execute `ClearSearchCommand`.

3. **Tests (`NodePaletteFilterTests.cs`)**:
   - Added an Xunit test suite consisting of 5 specific scenarios to validate filtering logic (empty state, case-insensitive substring matching, no-match isolation, and clearing).

### Manual Test Plan:
- Build the solution locally.
- Open the Visual Node Editor view.
- Type "timer" in the palette search box. The UI will instantly filter to display only the "Timers" category containing TON, TOF, and TP.
- Type "math". The UI will filter to display the "Math Operations" category nodes.
- Press `Esc` or click the clear button (`X`) within the search box; all original categories and nodes are restored and focus is cleared.

---
*PR created automatically by Jules for task [13872480204927778300](https://jules.google.com/task/13872480204927778300) started by @nokkies*