### PR TITLE
Fix canvas redraw performance by using incremental line updates

### DIFF
--- a/ModbusForge.Tests/Views/VisualNodeEditorPerfTests.cs
+++ b/ModbusForge.Tests/Views/VisualNodeEditorPerfTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+using ModbusForge.Models;
+using ModbusForge.Views;
+using Xunit;
+
+namespace ModbusForge.Tests.Views
+{
+    public class VisualNodeEditorPerfTests
+    {
+        [Fact]
+        public void GetConnectionsForNode_ShouldOnlyReturnTargetedConnections()
+        {
+            // Arrange: create a graph with 50 nodes and 100 connections
+            var connections = new List<NodeConnection>();
+
+            // Central node we will "drag"
+            var targetNodeId = "Node-0";
+
+            // Add 10 connections tied to the target node
+            for (int i = 1; i <= 10; i++)
+            {
+                var conn1 = new NodeConnection(targetNodeId, $"Node-{i}");
+                conn1.Id = $"Conn-Target-Src-{i}";
+                connections.Add(conn1);
+
+                var conn2 = new NodeConnection($"Node-{i + 10}", targetNodeId);
+                conn2.Id = $"Conn-Target-Dst-{i}";
+                connections.Add(conn2);
+            }
+
+            // Add 80 background connections not tied to the target node
+            for (int i = 1; i <= 80; i++)
+            {
+                var conn = new NodeConnection($"Node-Bg-{i}", $"Node-Bg-{i+1}");
+                conn.Id = $"Conn-Bg-{i}";
+                connections.Add(conn);
+            }
+
+            Assert.Equal(100, connections.Count);
+
+            // Simulate 100 mouse move events dragging targetNodeId
+            int operationsProcessed = 0;
+            int simulatedFrames = 100;
+
+            for (int frame = 0; frame < simulatedFrames; frame++)
+            {
+                // Act: get the localized connections for this node
+                var nodeConnections = VisualNodeEditor.GetConnectionsForNode(connections, targetNodeId).ToList();
+
+                // Assert per-frame expectations
+                Assert.Equal(20, nodeConnections.Count);
+                operationsProcessed += nodeConnections.Count;
+
+                foreach(var c in nodeConnections)
+                {
+                    Assert.True(c.SourceNodeId == targetNodeId || c.TargetNodeId == targetNodeId);
+                }
+            }
+
+            // Overall assert: Before this fix, operations would have been 100 * 100 = 10,000
+            // After this fix, it should strictly be 20 * 100 = 2,000
+            Assert.Equal(2000, operationsProcessed);
+        }
+    }
+}

--- a/ModbusForge/Views/VisualNodeEditor.xaml.cs
+++ b/ModbusForge/Views/VisualNodeEditor.xaml.cs
@@ -42,6 +42,9 @@ namespace ModbusForge.Views
         // Track event handlers for cleanup to prevent memory leaks
         private readonly Dictionary<string, List<(object Target, PropertyChangedEventHandler Handler)>> _nodeEventHandlers = new();
         
+        // Track connection lines to avoid recreating them
+        private readonly Dictionary<string, Line> _connectionLines = new();
+
         public VisualNodeEditor()
         {
             InitializeComponent();
@@ -328,6 +331,8 @@ namespace ModbusForge.Views
             }
             foreach (var element in elementsToRemove)
                 NodeCanvas.Children.Remove(element);
+
+            _connectionLines.Clear();
             
             // Draw connections using actual visual-tree positions where available
             foreach (var connection in _viewModel.Connections)
@@ -361,9 +366,48 @@ namespace ModbusForge.Views
                     e.Handled = true;
                 };
                 NodeCanvas.Children.Add(line);
+                _connectionLines[connection.Id] = line;
             }
         }
         
+        internal static IEnumerable<NodeConnection> GetConnectionsForNode(IEnumerable<NodeConnection> connections, string nodeId)
+        {
+            return connections.Where(c => c.SourceNodeId == nodeId || c.TargetNodeId == nodeId);
+        }
+
+        private void RefreshConnectionsForNode(string nodeId)
+        {
+            if (_viewModel == null || NodeCanvas == null) return;
+
+            var connections = GetConnectionsForNode(_viewModel.Connections, nodeId);
+
+            foreach (var connection in connections)
+            {
+                var startPoint = GetActualConnectorPosition(connection.SourceNodeId, "Output");
+                var endPoint   = GetActualConnectorPosition(connection.TargetNodeId, connection.TargetConnector);
+
+                // Update model so ViewModel stays consistent
+                if (startPoint.X != 0 || startPoint.Y != 0)
+                {
+                    connection.StartX = startPoint.X;
+                    connection.StartY = startPoint.Y;
+                }
+                if (endPoint.X != 0 || endPoint.Y != 0)
+                {
+                    connection.EndX = endPoint.X;
+                    connection.EndY = endPoint.Y;
+                }
+
+                if (_connectionLines.TryGetValue(connection.Id, out var line))
+                {
+                    line.X1 = connection.StartX;
+                    line.Y1 = connection.StartY;
+                    line.X2 = connection.EndX;
+                    line.Y2 = connection.EndY;
+                }
+            }
+        }
+
         private Line CreateConnectionLine(NodeConnection connection)
         {
             var line = new Line
@@ -1046,8 +1090,8 @@ namespace ModbusForge.Views
                     // Update connections
                     _viewModel.UpdateNodeConnections(_draggedNode.Id);
                     
-                    // Refresh connection lines to match new positions
-                    RefreshConnections();
+                    // Refresh connection lines to match new positions only for the dragged node
+                    RefreshConnectionsForNode(_draggedNode.Id);
                 }
             }
             else if (_isConnecting && !string.IsNullOrEmpty(_viewModel.PendingConnectionStart))


### PR DESCRIPTION
Fixed a canvas redraw performance issue where moving a single node forces the visual system to clear and re-add all Connection lines on every mouse movement tick. Instead of recreating elements, a tracking dictionary maps `Line` properties to connections, allowing O(N) updates per frame where N is the connections bound to the target node, greatly improving application stutter under load.

---
*PR created automatically by Jules for task [13151799482144246847](https://jules.google.com/task/13151799482144246847) started by @nokkies*