### PR TITLE
feat: add snap-to-grid and alignment tools to Visual Node Editor

### DIFF
--- a/ModbusForge.Tests/ViewModels/VisualNodeEditorSnapTests.cs
+++ b/ModbusForge.Tests/ViewModels/VisualNodeEditorSnapTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using ModbusForge.ViewModels;
+using ModbusForge.Views;
+using ModbusForge.Models;
+using Xunit;
+
+namespace ModbusForge.Tests.ViewModels
+{
+    public class VisualNodeEditorSnapTests
+    {
+        [Fact]
+        public void SnapToGrid_DefaultValue_Is_True()
+        {
+            var viewModel = new VisualNodeEditorViewModel();
+            Assert.True(viewModel.SnapToGrid);
+            Assert.Equal(20, viewModel.GridSize);
+        }
+
+        [Theory]
+        [InlineData(0, 20, 0)]
+        [InlineData(9, 20, 0)]
+        [InlineData(10, 20, 20)]
+        [InlineData(19, 20, 20)]
+        [InlineData(20, 20, 20)]
+        [InlineData(-5, 20, 0)]
+        public void SnapToGrid_HelperMethod_ReturnsExpectedValues(double input, int gridSize, double expected)
+        {
+            var result = VisualNodeEditor.SnapToGrid(input, gridSize);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void AlignLeftCommand_NoSelection_IsNoOp()
+        {
+            var viewModel = new VisualNodeEditorViewModel();
+            viewModel.SelectedNode = null;
+
+            // This should not throw any exception
+            var exception = Record.Exception(() => viewModel.AlignLeftCommand.Execute(null));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void AlignLeftCommand_OneSelectedNode_IsNoOp()
+        {
+            var viewModel = new VisualNodeEditorViewModel();
+            var node = new VisualNode { X = 10, Y = 10 };
+            viewModel.SelectedNode = node;
+
+            viewModel.AlignLeftCommand.Execute(null);
+
+            // Verify position didn't change (no-op)
+            Assert.Equal(10, node.X);
+            Assert.Equal(10, node.Y);
+        }
+
+        [Fact]
+        public void DistributeHorizontallyCommand_LessThanTwoNodes_IsNoOp()
+        {
+            var viewModel = new VisualNodeEditorViewModel();
+
+            // Case 1: 0 nodes
+            viewModel.SelectedNode = null;
+            viewModel.DistributeHorizontallyCommand.Execute(null);
+
+            // Case 2: 1 node
+            var node = new VisualNode { X = 10, Y = 10 };
+            viewModel.SelectedNode = node;
+            viewModel.DistributeHorizontallyCommand.Execute(null);
+
+            // Position should not change
+            Assert.Equal(10, node.X);
+            Assert.Equal(10, node.Y);
+        }
+    }
+}

--- a/ModbusForge/ViewModels/VisualNodeEditorViewModel.cs
+++ b/ModbusForge/ViewModels/VisualNodeEditorViewModel.cs
@@ -90,12 +90,26 @@ namespace ModbusForge.ViewModels
         [ObservableProperty]
         private string _searchText = "";
 
+        [ObservableProperty]
+        private bool _snapToGrid = true;
+
+        [ObservableProperty]
+        private int _gridSize = 20;
+
         public ObservableCollection<PaletteCategory> PaletteCategories { get; } = new ObservableCollection<PaletteCategory>();
 
         public UndoRedoService UndoRedo { get; } = new UndoRedoService();
 
+        public IRelayCommand AlignLeftCommand { get; }
+        public IRelayCommand AlignTopCommand { get; }
+        public IRelayCommand DistributeHorizontallyCommand { get; }
+
         public VisualNodeEditorViewModel()
         {
+            AlignLeftCommand = new RelayCommand(AlignLeft);
+            AlignTopCommand = new RelayCommand(AlignTop);
+            DistributeHorizontallyCommand = new RelayCommand(DistributeHorizontally);
+
             // Initialize with a default program
             var defaultProgram = new ProgramModel { Name = "Main", ExecutionOrder = 0 };
             ProgramTree.Programs.Add(defaultProgram);
@@ -601,6 +615,36 @@ namespace ModbusForge.ViewModels
             }
         }
         
+        private List<VisualNode> GetSelection()
+        {
+            if (SelectedNode != null)
+            {
+                return new List<VisualNode> { SelectedNode };
+            }
+            return new List<VisualNode>();
+        }
+
+        private void AlignLeft()
+        {
+            var selection = GetSelection();
+            if (selection.Count < 2) return;
+            // No-op for now, needs multi-select
+        }
+
+        private void AlignTop()
+        {
+            var selection = GetSelection();
+            if (selection.Count < 2) return;
+            // No-op for now, needs multi-select
+        }
+
+        private void DistributeHorizontally()
+        {
+            var selection = GetSelection();
+            if (selection.Count < 3) return; // Distribute needs at least 3
+            // No-op for now, needs multi-select
+        }
+
         partial void OnSelectedProgramChanged(ProgramModel? value)
         {
             if (value != null)

--- a/ModbusForge/Views/VisualNodeEditor.xaml
+++ b/ModbusForge/Views/VisualNodeEditor.xaml
@@ -181,6 +181,11 @@
                         <Button Content="Clear All" Command="{Binding ClearAllCommand}" Margin="0,0,10,0"/>
                         <Button Content="Auto Layout" Command="{Binding AutoLayoutCommand}" Margin="0,0,10,0"/>
                         <Separator Margin="10,0"/>
+                        <ToggleButton Content="Snap to Grid" IsChecked="{Binding SnapToGrid}" Margin="0,0,10,0"/>
+                        <Button Content="Align L" Command="{Binding AlignLeftCommand}" Margin="0,0,5,0" Padding="8,4"/>
+                        <Button Content="Align T" Command="{Binding AlignTopCommand}" Margin="0,0,5,0" Padding="8,4"/>
+                        <Button Content="Distrib H" Command="{Binding DistributeHorizontallyCommand}" Margin="0,0,10,0" Padding="8,4"/>
+                        <Separator Margin="10,0"/>
                         <Button x:Name="TagBrowserButton" Content="🏷️ Tags" Click="TagBrowserButton_Click" Margin="0,0,10,0" Padding="8,4"/>
                         <Button x:Name="WatchWindowButton" Content="👁️ Watch" Click="WatchWindowButton_Click" Margin="0,0,10,0" Padding="8,4"/>
                         <Separator Margin="10,0"/>

--- a/ModbusForge/Views/VisualNodeEditor.xaml.cs
+++ b/ModbusForge/Views/VisualNodeEditor.xaml.cs
@@ -1314,8 +1314,23 @@ namespace ModbusForge.Views
                     var command = new ModbusForge.Services.EditorCommands.MoveNodeCommand(_draggedNode, _originalNodePosition, newPos);
                     command.Execute();
                     _viewModel.UndoRedo.Push(command);
-                    RefreshConnections();
                 }
+                else
+                {
+                    // Snapped back to original position, reset model coordinates
+                    _draggedNode.X = _originalNodePosition.X;
+                    _draggedNode.Y = _originalNodePosition.Y;
+                }
+
+                // Ensure visual border matches final model coordinates
+                var nodeBorder = FindNodeBorder(_draggedNode.Id);
+                if (nodeBorder != null)
+                {
+                    Canvas.SetLeft(nodeBorder, _draggedNode.X);
+                    Canvas.SetTop(nodeBorder, _draggedNode.Y);
+                }
+
+                RefreshConnections();
             }
 
             // Reset dragging state only - connections persist until user completes or cancels them

--- a/ModbusForge/Views/VisualNodeEditor.xaml.cs
+++ b/ModbusForge/Views/VisualNodeEditor.xaml.cs
@@ -1286,11 +1286,24 @@ namespace ModbusForge.Views
             return null!;
         }
         
+        public static double SnapToGrid(double value, int gridSize)
+        {
+            if (gridSize <= 0) return value;
+            return System.Math.Floor(value / gridSize + 0.5) * gridSize;
+        }
+
         private void Canvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
             if (_isDraggingNode && _draggedNode != null && _viewModel != null)
             {
                 var newPos = new Point(_draggedNode.X, _draggedNode.Y);
+
+                if (_viewModel.SnapToGrid)
+                {
+                    newPos.X = SnapToGrid(newPos.X, _viewModel.GridSize);
+                    newPos.Y = SnapToGrid(newPos.Y, _viewModel.GridSize);
+                }
+
                 if (_originalNodePosition.X != newPos.X || _originalNodePosition.Y != newPos.Y)
                 {
                     // Node was actually moved, so register an undo command


### PR DESCRIPTION
This PR implements a new "Snap to Grid" feature in the Visual Node Editor, alongside UI placeholders for future multi-select alignment tools.

### What's included
- A `SnapToGrid` toggle button in the node editor toolbar (defaults to true).
- Snapping math in `VisualNodeEditor.xaml.cs` that snaps dropped nodes to multiples of `GridSize` (default 20px).
- Three new alignment toolbar buttons: `Align L`, `Align T`, and `Distrib H`.
- ViewModel commands for the alignment tools. Currently, since the editor only supports single-node selection (`SelectedNode`), these commands act as safe no-ops and will be expanded in a future multi-select PR.
- Unit tests validating the default snap state, the `SnapToGrid` rounding logic, and ensuring the new alignment commands correctly handle single or empty selections without throwing exceptions.

### Manual Test Plan
1. Launch ModbusForge and open the Visual Node Editor.
2. Enable "Snap to Grid" in the toolbar. Drag a node and release it -> verify its position is aligned to a 20px grid.
3. Disable "Snap to Grid". Drag a node and release it -> verify its position is free-floating and unaligned.
4. Click the new `Align L`, `Align T`, and `Distrib H` buttons -> verify nothing crashes and they do nothing (since multi-select is not yet implemented).

### Test Output

```
  Determining projects to restore...
  All projects are up-to-date for restore.
  UI.TestFramework -> /app/UI.TestFramework/bin/Debug/net8.0-windows/UI.TestFramework.dll
  ModbusForge -> /app/ModbusForge/bin/Debug/net8.0-windows/ModbusForge.dll
  ModbusForge.Tests -> /app/ModbusForge.Tests/bin/Debug/net8.0-windows/ModbusForge.Tests.dll

Build succeeded.
    33 Warning(s)
    0 Error(s)

Time Elapsed 00:00:03.20

Test run for /app/ModbusForge.Tests/bin/Debug/net8.0-windows/ModbusForge.Tests.dll (.NETCoreApp,Version=v8.0)
VSTest version 18.0.1 (x64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:   206, Skipped:     0, Total:   206, Duration: 1 s - ModbusForge.Tests.dll (net8.0-windows)
```

---
*PR created automatically by Jules for task [15869485517664627817](https://jules.google.com/task/15869485517664627817) started by @nokkies*